### PR TITLE
Inject the api and apps_domain if a system domain is specified

### DIFF
--- a/update-integration-configs/task
+++ b/update-integration-configs/task
@@ -59,6 +59,10 @@ function main() {
     local new_cats_integration_config
     new_cats_integration_config=$(cat "integration-configs/${CATS_INTEGRATION_CONFIG_FILE}" | jq ".admin_password=\"${admin_password}\"")
 
+    if [ -n "${SYSTEM_DOMAIN}" ]; then
+      new_cats_integration_config=$(echo "${new_cats_integration_config}" | jq ".api=\"api.${SYSTEM_DOMAIN}\" | .apps_domain=\"${SYSTEM_DOMAIN}\"")
+    fi
+
     echo "${new_cats_integration_config}" > "integration-configs/${CATS_INTEGRATION_CONFIG_FILE}"
   fi
 

--- a/update-integration-configs/task.yml
+++ b/update-integration-configs/task.yml
@@ -32,3 +32,8 @@ params:
   # - Required
   # - Filepath to the vars-store yaml file creds will be drawn from
   # - The path is relative to root of the `vars-store` input
+
+  SYSTEM_DOMAIN:
+  # - Optional
+  # - CF system base domain e.g. `my-cf.com`
+  # - Should match the value passed to `bosh-deploy`


### PR DESCRIPTION
Hi,

This PR adds support for injecting the `api` and `apps_domain` values into the CATs integration config JSON file. We noticed that the apps_domain is set to the same value as the system_domain in the cf-deployment manifest (see [here](https://github.com/cloudfoundry/cf-deployment/blob/master/cf-deployment.yml#L28) for an example), so we didn't add support for separate domains.