### PR TITLE
Optionally allow some parameters to be filepaths

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -44,17 +44,26 @@ function commit_bbl_state_file {
 
 function write_bbl_certs() {
   set +x
-  if [[ "${BBL_LB_CERT}" == *"BEGIN CERTIFICATE"* ]]; then
+  if [ ! -f "${BBL_LB_CERT}" ]; then
     echo "$BBL_LB_CERT" > /tmp/bbl-cert
     bbl_cert_path="/tmp/bbl-cert"
   else
     bbl_cert_path="${BBL_LB_CERT}"
   fi
-  if [[ "${BBL_LB_KEY}" == *"BEGIN RSA PRIVATE KEY"* ]]; then
+  if [ ! -f "${BBL_LB_KEY}" ]; then
     echo "$BBL_LB_KEY" > /tmp/bbl-key
     bbl_key_path="/tmp/bbl-key"
   else
     bbl_key_path="${BBL_LB_KEY}"
+  fi
+  set -x
+}
+
+function write_service_account_key() {
+  set +x
+  if [ ! -f "${BBL_GCP_SERVICE_ACCOUNT_KEY}" ]; then
+    echo "${BBL_GCP_SERVICE_ACCOUNT_KEY}" > /tmp/google_service_account.json
+    export BBL_GCP_SERVICE_ACCOUNT_KEY="/tmp/google_service_account.json"
   fi
   set -x
 }
@@ -79,14 +88,15 @@ function main() {
       name_flag="--name ${BBL_ENV_NAME}"
     fi
 
-    bbl --debug up ${name_flag} > "${root_dir}"/bbl_up.txt
-
     local domain_flag
     domain_flag=""
 
     if [ "${BBL_IAAS}" == "gcp" ]; then
+      write_service_account_key
       domain_flag="--domain=${LB_DOMAIN}"
     fi
+
+    bbl --debug up ${name_flag} > "${root_dir}"/bbl_up.txt
 
     # The two commands below amount to "create or update"
     bbl \

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -44,8 +44,18 @@ function commit_bbl_state_file {
 
 function write_bbl_certs() {
   set +x
-  echo "$BBL_LB_CERT" > /tmp/bbl-cert
-  echo "$BBL_LB_KEY" > /tmp/bbl-key
+  if [[ "${BBL_LB_CERT}" == *"BEGIN CERTIFICATE"* ]]; then
+    echo "$BBL_LB_CERT" > /tmp/bbl-cert
+    bbl_cert_path="/tmp/bbl-cert"
+  else
+    bbl_cert_path="${BBL_LB_CERT}"
+  fi
+  if [[ "${BBL_LB_KEY}" == *"BEGIN RSA PRIVATE KEY"* ]]; then
+    echo "$BBL_LB_KEY" > /tmp/bbl-key
+    bbl_key_path="/tmp/bbl-key"
+  else
+    bbl_key_path="${BBL_LB_KEY}"
+  fi
   set -x
 }
 
@@ -56,6 +66,8 @@ function main() {
   check_fast_fails
 
   pushd "bbl-state/${BBL_STATE_DIR}"
+    local bbl_cert_path
+    local bbl_cert_key
     write_bbl_certs
 
     bbl version
@@ -81,16 +93,16 @@ function main() {
       --debug \
       create-lbs \
       --type=cf \
-      --cert=/tmp/bbl-cert \
-      --key=/tmp/bbl-key \
+      --cert="${bbl_cert_path}" \
+      --key="${bbl_key_path}" \
       --skip-if-exists \
       ${domain_flag} > "${root_dir}"/bbl_create_lbs.txt
 
     bbl \
       --debug \
       update-lbs \
-      --cert=/tmp/bbl-cert \
-      --key=/tmp/bbl-key \
+      --cert="${bbl_cert_path}" \
+      --key="${bbl_key_path}" \
       ${domain_flag} > "${root_dir}"/bbl_update_lbs.txt
   popd
 }


### PR DESCRIPTION
To make these tasks more flexible, allow the load balancer certs and service account json (when GCP) to be filepaths or their contents.