### PR TITLE
Remove bosh-init from Dockerfile

### DIFF
--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -68,13 +68,6 @@ RUN \
   chmod +x terraform && \
   rm -rf /tmp/*
 
-RUN \
-  wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.99-linux-amd64 -P /tmp && \
-  mv /tmp/bosh-init-0.0.99-linux-amd64 /usr/local/bin/bosh-init && \
-  cd /usr/local/bin && \
-  echo "00ccaf07a11bd8206407f83f1e606e16f3475bf3 bosh-init" | sha1sum -c - && \
-  chmod +x bosh-init
-
 ENV GOPATH /go
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 RUN \


### PR DESCRIPTION
Not sure if it's retained for a reason, but it doesn't seem like it's used (and it's also an older version with some buggy behavior). Dunno; PR if useful.