### PR TITLE
Use bbl print-env to setup bosh env vars in other tasks.

### DIFF
--- a/bosh-cleanup/task
+++ b/bosh-cleanup/task
@@ -4,10 +4,7 @@ set -exu
 function setup_bosh_env_vars() {
   set +x
   pushd "bbl-state/${BBL_STATE_DIR}"
-    export BOSH_CA_CERT="$(bbl director-ca-cert)"
-    export BOSH_ENVIRONMENT=$(bbl director-address)
-    export BOSH_CLIENT=$(bbl director-username)
-    export BOSH_CLIENT_SECRET=$(bbl director-password)
+    eval "$(bbl print-env)"
   popd
   set -x
 }

--- a/bosh-delete-deployment/task
+++ b/bosh-delete-deployment/task
@@ -11,10 +11,7 @@ function check_input_params() {
 function setup_bosh_env_vars() {
   set +x
   pushd "bbl-state/${BBL_STATE_DIR}"
-    export BOSH_CA_CERT="$(bbl director-ca-cert)"
-    export BOSH_ENVIRONMENT=$(bbl director-address)
-    export BOSH_CLIENT=$(bbl director-username)
-    export BOSH_CLIENT_SECRET=$(bbl director-password)
+    eval "$(bbl print-env)"
   popd
   set -x
 }

--- a/bosh-upload-stemcell-from-cf-deployment/task
+++ b/bosh-upload-stemcell-from-cf-deployment/task
@@ -4,10 +4,7 @@ set -eux
 function setup_bosh_env_vars() {
   set +x
   pushd "bbl-state/${BBL_STATE_DIR}"
-    export BOSH_CA_CERT="$(bbl director-ca-cert)"
-    export BOSH_ENVIRONMENT=$(bbl director-address)
-    export BOSH_CLIENT=$(bbl director-username)
-    export BOSH_CLIENT_SECRET=$(bbl director-password)
+    eval "$(bbl print-env)"
   popd
   set -x
 }


### PR DESCRIPTION
Set up in bosh-cleanup, bosh-delete-deployment, and
bosh-upload-stemcell-from-cf-deployment.

Similar to this PR: https://github.com/cloudfoundry/cf-deployment-concourse-tasks/pull/24