### PR TITLE
Use shared-functions for all setup_bosh_env_vars calls

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -117,7 +117,7 @@ function main() {
     fi
 
 
-    bbl --debug up ${name_flag} ${ops_arguments} > "${root_dir}/bbl_up.txt"
+    bbl --debug up ${name_flag} ${ops_arguments} ${BBL_EXTRA_FLAGS} > "${root_dir}/bbl_up.txt"
 
     # The two commands below amount to "create or update"
     bbl \

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -80,6 +80,11 @@ params:
   # - A label to apply to the bbl environment
   # - Label will appear in the IaaS metadata/interface
 
+  BBL_EXTRA_FLAGS:
+  # - Optional
+  # - Extra flags to pass into bbl up
+  # - Can be used for experimental features such as `--credhub`
+
   GIT_COMMIT_EMAIL:
   GIT_COMMIT_USERNAME:
   # - Optional

--- a/bosh-cleanup/task
+++ b/bosh-cleanup/task
@@ -1,16 +1,8 @@
 #!/bin/bash
 set -exu
 
-function setup_bosh_env_vars() {
-  set +x
-  pushd "bbl-state/${BBL_STATE_DIR}"
-    export BOSH_CA_CERT="$(bbl director-ca-cert)"
-    export BOSH_ENVIRONMENT=$(bbl director-address)
-    export BOSH_CLIENT=$(bbl director-username)
-    export BOSH_CLIENT_SECRET=$(bbl director-password)
-  popd
-  set -x
-}
+# shellcheck disable=SC1091
+source cf-deployment-concourse-tasks/shared-functions
 
 function bosh_clean_up() {
   if [ -z "${CLEAN_ALL}" ] || [ "${CLEAN_ALL}" = true ]; then

--- a/bosh-delete-deployment/task
+++ b/bosh-delete-deployment/task
@@ -1,22 +1,14 @@
 #!/bin/bash
 set -exu
 
-function check_input_params() {
+# shellcheck disable=SC1091
+source cf-deployment-concourse-tasks/shared-functions
+
+function check_delete_deployment_params() {
   if [ -z "$DEPLOYMENT_NAME" ]; then
     echo "DEPLOYMENT_NAME has not been set"
     exit 1
   fi
-}
-
-function setup_bosh_env_vars() {
-  set +x
-  pushd "bbl-state/${BBL_STATE_DIR}"
-    export BOSH_CA_CERT="$(bbl director-ca-cert)"
-    export BOSH_ENVIRONMENT=$(bbl director-address)
-    export BOSH_CLIENT=$(bbl director-username)
-    export BOSH_CLIENT_SECRET=$(bbl director-password)
-  popd
-  set -x
 }
 
 function bosh_delete_deployment() {
@@ -26,7 +18,7 @@ function bosh_delete_deployment() {
 }
 
 function main() {
-  check_input_params
+  check_delete_deployment_params
   setup_bosh_env_vars
   bosh_delete_deployment
 }

--- a/bosh-upload-stemcell-from-cf-deployment/task
+++ b/bosh-upload-stemcell-from-cf-deployment/task
@@ -1,18 +1,10 @@
 #!/bin/bash
 set -eux
 
-function setup_bosh_env_vars() {
-  set +x
-  pushd "bbl-state/${BBL_STATE_DIR}"
-    export BOSH_CA_CERT="$(bbl director-ca-cert)"
-    export BOSH_ENVIRONMENT=$(bbl director-address)
-    export BOSH_CLIENT=$(bbl director-username)
-    export BOSH_CLIENT_SECRET=$(bbl director-password)
-  popd
-  set -x
-}
+# shellcheck disable=SC1091
+source cf-deployment-concourse-tasks/shared-functions
 
-function check_input_params() {
+function check_upload_stemcell_params() {
   if [ -z "$INFRASTRUCTURE" ]; then
     echo "INFRASTRUCTURE has not been set"
     exit 1
@@ -86,7 +78,7 @@ function upload_stemcell() {
 }
 
 function main() {
-  check_input_params
+  check_upload_stemcell_params
   setup_bosh_env_vars
   upload_stemcell
 }

--- a/collect-ops-files/task
+++ b/collect-ops-files/task
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-check_params() {
+check_collect_opsfiles_params() {
   if [ ! -d ${ROOT_DIR}/base-ops-files/${BASE_OPS_FILE_DIR} ]; then
     echo "[ERROR] base-ops-files/${BASE_OPS_FILE_DIR} must exist in order to collect operations files."
     exit 1
@@ -58,7 +58,7 @@ collect_new_operations() {
 main() {
   ROOT_DIR="${1}"
 
-  check_params
+  check_collect_opsfiles_params
   create_collection_directory
   set_collection_path
   collect_base_operations


### PR DESCRIPTION
This accomplishes essentially the same function as PR #26 but goes about it slightly differently. In this case, the `setup_bosh_env_vars` function from `shared-functions` is used in place of every inline `setup_bosh_env_vars` function definition. Some other functions have been renamed to avoid name collisions.

This is needed to implement support for jumpboxes in the BBL pipeline since `eval "$(bbl print-env)"` now also starts up the ssh tunnel to connect to the BOSH director through the jumpbox. 

The relevant Tracker story is here: https://www.pivotaltracker.com/story/show/146740257