### PR TITLE
Allow `bbl up --credhub` in CI pipelines

### DIFF
--- a/bbl-destroy/task.yml
+++ b/bbl-destroy/task.yml
@@ -31,3 +31,15 @@ params:
   # - Optional
   # - You may choose the git committer username and email address by setting these
   # - If you leave them blank, they are set to 'CI Bot' and 'cf-release-integration@pivotal.io', respectively
+
+  # AWS Configuration Params
+  # - Required for AWS w/ jumpbox
+  BBL_AWS_ACCESS_KEY_ID:
+  BBL_AWS_SECRET_ACCESS_KEY:
+
+  # GCP Configuration Params
+  # - Required for GCP w/ jumpbox
+  BBL_GCP_SERVICE_ACCOUNT_KEY:
+  # - Key content or path to the file containing credentials downloaded from GCP
+  # - Path is relative to the BBL_STATE_DIR specified above
+  BBL_GCP_PROJECT_ID:

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -29,14 +29,12 @@ run:
 params:
   # AWS Configuration Params
   # - Required for AWS
-  # - Must be empty for GCP
   BBL_AWS_ACCESS_KEY_ID:
   BBL_AWS_SECRET_ACCESS_KEY:
   BBL_AWS_REGION:
 
   # GCP Configuration Params
   # - Required for GCP
-  # - Must be empty for AWS
   BBL_GCP_SERVICE_ACCOUNT_KEY:
   # - Key content or path to the file containing credentials downloaded from GCP
   # - Path is relative to the BBL_STATE_DIR specified below

--- a/bosh-cleanup/task.yml
+++ b/bosh-cleanup/task.yml
@@ -25,3 +25,15 @@ params:
   # - Optional
   # - Boolean determines whether to use `--clean-all` parameter to
   # - `bosh clean-up`
+
+  # AWS Configuration Params
+  # - Required for AWS w/ jumpbox
+  BBL_AWS_ACCESS_KEY_ID:
+  BBL_AWS_SECRET_ACCESS_KEY:
+
+  # GCP Configuration Params
+  # - Required for GCP w/ jumpbox
+  BBL_GCP_SERVICE_ACCOUNT_KEY:
+  # - Key content or path to the file containing credentials downloaded from GCP
+  # - Path is relative to the BBL_STATE_DIR specified above
+  BBL_GCP_PROJECT_ID:

--- a/bosh-delete-deployment/task.yml
+++ b/bosh-delete-deployment/task.yml
@@ -22,3 +22,15 @@ params:
   # - Defaults to the root of the `bbl-state` input
 
   DEPLOYMENT_NAME: cf
+
+  # AWS Configuration Params
+  # - Required for AWS w/ jumpbox
+  BBL_AWS_ACCESS_KEY_ID:
+  BBL_AWS_SECRET_ACCESS_KEY:
+
+  # GCP Configuration Params
+  # - Required for GCP w/ jumpbox
+  BBL_GCP_SERVICE_ACCOUNT_KEY:
+  # - Key content or path to the file containing credentials downloaded from GCP
+  # - Path is relative to the BBL_STATE_DIR specified above
+  BBL_GCP_PROJECT_ID:

--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -100,3 +100,15 @@ params:
   # - Optional
   # - This will cause the task to fail if you are not using the DEPLOY_WITH_UPTIME_MEASUREMENTS flag
   # - It will cause the concourse task to fail if you do not have perfect uptime
+
+  # AWS Configuration Params
+  # - Required for AWS w/ jumpbox
+  BBL_AWS_ACCESS_KEY_ID:
+  BBL_AWS_SECRET_ACCESS_KEY:
+
+  # GCP Configuration Params
+  # - Required for GCP w/ jumpbox
+  BBL_GCP_SERVICE_ACCOUNT_KEY:
+  # - Key content or path to the file containing credentials downloaded from GCP
+  # - Path is relative to the BBL_STATE_DIR specified above
+  BBL_GCP_PROJECT_ID:

--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -82,3 +82,15 @@ params:
   # - Optional
   # - This will cause the task to fail if you are not using the DEPLOY_WITH_UPTIME_MEASUREMENTS flag
   # - It will cause the concourse task to fail if you do not have perfect uptime
+
+  # AWS Configuration Params
+  # - Required for AWS w/ jumpbox
+  BBL_AWS_ACCESS_KEY_ID:
+  BBL_AWS_SECRET_ACCESS_KEY:
+
+  # GCP Configuration Params
+  # - Required for GCP w/ jumpbox
+  BBL_GCP_SERVICE_ACCOUNT_KEY:
+  # - Key content or path to the file containing credentials downloaded from GCP
+  # - Path is relative to the BBL_STATE_DIR specified above
+  BBL_GCP_PROJECT_ID:

--- a/bosh-upload-stemcell-from-cf-deployment/task.yml
+++ b/bosh-upload-stemcell-from-cf-deployment/task.yml
@@ -25,3 +25,15 @@ params:
   # - Required
   # - Used to determine which stemcell will be uploaded
   # - Must be one of: aws, bosh-lite, google, or vsphere
+
+  # AWS Configuration Params
+  # - Required for AWS w/ jumpbox
+  BBL_AWS_ACCESS_KEY_ID:
+  BBL_AWS_SECRET_ACCESS_KEY:
+
+  # GCP Configuration Params
+  # - Required for GCP w/ jumpbox
+  BBL_GCP_SERVICE_ACCOUNT_KEY:
+  # - Key content or path to the file containing credentials downloaded from GCP
+  # - Path is relative to the BBL_STATE_DIR specified above
+  BBL_GCP_PROJECT_ID:

--- a/shared-functions
+++ b/shared-functions
@@ -57,6 +57,7 @@ function setup_bosh_env_vars() {
   pushd bbl-state/"${BBL_STATE_DIR}"
     eval "$(bbl print-env)"
   popd
+  trap "pkill ssh || true" EXIT INT TERM
   set -ux
 }
 


### PR DESCRIPTION
This PR contains a couple changes designed to enable using `bbl up --credhub` in CI pipelines.

The first is that, in order to prevent containers from hanging for a long time after jobs which run `eval "$(bbl print-env)"` (which opens an ssh connection when credhub is enabled), the `setup_bosh_env_vars` task in `shared_functions` kills ssh connections on exit.

The second change is due to bbl no longer persisting IAAS credentials in `bbl-state.json` when credhub is enabled. As a result, when credhub is enabled, we must pass in the IAAS credentials manually to every task which runs a bbl command (including `bbl print-env`).

/cc @mcwumbly