### PR TITLE
Kill ssh connections for bbl --credhub manually

### DIFF
--- a/bbl-destroy/task
+++ b/bbl-destroy/task
@@ -19,6 +19,8 @@ function commit_bbl_state_file {
     shopt -s dotglob
     cp -R bbl-state/* updated-bbl-state/
   popd
+
+  close_bbl_ssh_connection
 }
 
 function main() {

--- a/bosh-cleanup/task
+++ b/bosh-cleanup/task
@@ -15,6 +15,7 @@ function bosh_clean_up() {
 function main() {
   setup_bosh_env_vars
   bosh_clean_up
+  close_bbl_ssh_connection
 }
 
 main

--- a/bosh-delete-deployment/task
+++ b/bosh-delete-deployment/task
@@ -21,6 +21,7 @@ function main() {
   check_delete_deployment_params
   setup_bosh_env_vars
   bosh_delete_deployment
+  close_bbl_ssh_connection
 }
 
 main

--- a/bosh-deploy-with-created-release/task
+++ b/bosh-deploy-with-created-release/task
@@ -36,6 +36,7 @@ main() {
   fi
   bosh_interpolate "${root_dir}" "$(grep final_name release/config/final.yml | awk '{print $2}')"
   bosh_deploy
+  close_bbl_ssh_connection
 }
 
 trap commit_vars_store EXIT

--- a/bosh-deploy/task
+++ b/bosh-deploy/task
@@ -11,6 +11,7 @@ function main() {
   fi
   bosh_interpolate
   bosh_deploy
+  close_bbl_ssh_connection
 }
 
 trap commit_vars_store EXIT

--- a/bosh-upload-stemcell-from-cf-deployment/task
+++ b/bosh-upload-stemcell-from-cf-deployment/task
@@ -81,6 +81,7 @@ function main() {
   check_upload_stemcell_params
   setup_bosh_env_vars
   upload_stemcell
+  close_bbl_ssh_connection
 }
 
 main

--- a/shared-functions
+++ b/shared-functions
@@ -57,12 +57,14 @@ function setup_bosh_env_vars() {
   pushd bbl-state/"${BBL_STATE_DIR}"
     eval "$(bbl print-env)"
   popd
+  set -ux
+}
 
+function close_bbl_ssh_connection() {
   # Kill all ssh connections on exit.
   # This is needed so that tasks using bbl print-env in a credhub environment
   # don't hang after the script is finished.
-  trap "pkill ssh || true" INT TERM
-  set -ux
+  pkill ssh || true
 }
 
 function bosh_interpolate() {


### PR DESCRIPTION
The shared function `setup_bosh_env_vars` runs `eval "$(bbl print-env)"`; when the bbl environment has a jumpbox, this will create an SSH connection to the jumpbox. The SSH connection does not close on its own, which means that Concourse will keep containers alive for an undesired period of time (around 10 minutes) after the job has actually finished.

The previous approach to this, in PR #28, used `trap pkill ssh || true` in `setup_bosh_env_vars`. This conflicted with traps for committing var-stores, so instead in this PR, we are killing ssh connections manually at the end of each task which runs `setup_bosh_env_vars`.

We have confirmed that this works both with and without a jumpbox in the BBL pipeline.