### PR TITLE
Allow dynamic list of feature flags to be enabled/disabled

### DIFF
--- a/set-feature-flags/task
+++ b/set-feature-flags/task
@@ -5,19 +5,27 @@ if [ -z "${SYSTEM_DOMAIN}" ]; then
   exit 1
 fi
 
-function set_diego_docker() {
-  if ${DIEGO_DOCKER}; then
-    cf enable-feature-flag diego_docker
-  else
-    cf disable-feature-flag diego_docker
+function set_enabled_feature_flags() {
+  if [ ! -z "${ENABLED_FEATURE_FLAGS}" ]; then
+    for flag in $ENABLED_FEATURE_FLAGS; do
+      set_feature_flag "$flag" true
+    done
   fi
 }
 
-function set_task_creation() {
-  if ${TASK_CREATION}; then
-    cf enable-feature-flag task_creation
+function set_disabled_feature_flags() {
+  if [ ! -z "${DISABLED_FEATURE_FLAGS}" ]; then
+    for flag in $DISABLED_FEATURE_FLAGS; do
+      set_feature_flag "$flag" false
+    done
+  fi
+}
+
+function set_feature_flag() {
+  if [ $2 == true ]; then
+    cf enable-feature-flag "$1"
   else
-    cf disable-feature-flag task_creation
+    cf disable-feature-flag "$1"
   fi
 }
 
@@ -33,8 +41,8 @@ function main() {
 
   cf_login
 
-  set_diego_docker
-  set_task_creation
+  set_enabled_feature_flags
+  set_disabled_feature_flags
 
   cf feature-flags
 }

--- a/set-feature-flags/task.yml
+++ b/set-feature-flags/task.yml
@@ -12,14 +12,6 @@ inputs:
 - name: vars-store # - The BOSH deployment's vars-store yaml file
 
 params:
-  DIEGO_DOCKER: true
-  # - Required
-  # - This will either enable or disable the diego_docker feature-flag
-
-  TASK_CREATION: true
-  # - Required
-  # - This will either enable or disable the task_creation feature-flag
-
   SYSTEM_DOMAIN:
   # - Required
   # - CF system base domain e.g. `my-cf.com`
@@ -28,6 +20,14 @@ params:
   # - Required
   # - Filepath to the BOSH deployment vars-store yaml file
   # - The path is relative to root of the `vars-store` input
+
+  ENABLED_FEATURE_FLAGS:
+  # - Optional
+  # - Space seperated list of feature flag names to enable
+
+  DISABLED_FEATURE_FLAGS:
+  # - Optional
+  # - Space seperated list of feature flag names to disable
 
 run:
   path: cf-deployment-concourse-tasks/set-feature-flags/task


### PR DESCRIPTION
The current set-feature-flag task only allows diego_docker + task_creation to be set. We would like to be able to enable/disable any feature flags.

This PR is an alternative design, its more a conversation starter. Thoughts?

Note: Totally not backward compatible or anything sensible like that.