### PR TITLE
Track the entire contents of the bbl state dir

### DIFF
--- a/bbl-destroy/task
+++ b/bbl-destroy/task
@@ -3,15 +3,15 @@
 # shellcheck disable=SC1091
 source cf-deployment-concourse-tasks/shared-functions
 
-function commit_bbl_state_file {
+function commit_bbl_state_dir {
   local root_dir
   root_dir="${1}"
 
   pushd "${root_dir}/bbl-state/${BBL_STATE_DIR}"
     if [[ -n $(git status --porcelain) ]]; then
       set_git_config
-      git add --all bbl-state.json
-      git commit -m "Remove bbl-state.json"
+      git add --all .
+      git commit -m "Remove bbl state dir"
     fi
   popd
 
@@ -36,6 +36,6 @@ function main() {
   close_bbl_ssh_connection
 }
 
-trap "commit_bbl_state_file ${PWD}" EXIT
+trap "commit_bbl_state_dir ${PWD}" EXIT
 
 main ${PWD}

--- a/bbl-destroy/task.yml
+++ b/bbl-destroy/task.yml
@@ -9,7 +9,7 @@ image_resource:
 
 inputs:
 - name: cf-deployment-concourse-tasks  # - This repo
-- name: bbl-state  # - The Director's `bbl-state.json`
+- name: bbl-state  # - The Director's bbl state dir
 
 outputs:
 - name: updated-bbl-state

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -23,14 +23,14 @@ function check_fast_fails() {
   set -x
 }
 
-function commit_bbl_state_file {
+function commit_bbl_state_dir {
   local root_dir
   root_dir="${1}"
 
   pushd "${root_dir}/bbl-state/${BBL_STATE_DIR}"
     if [[ -n $(git status --porcelain) ]]; then
       set_git_config
-      git add bbl-state.json
+      git add .
       git commit -m "Update bbl-state.json"
     fi
   popd
@@ -135,6 +135,6 @@ function main() {
   popd
 }
 
-trap "commit_bbl_state_file ${PWD}" EXIT
+trap "commit_bbl_state_dir ${PWD}" EXIT
 
 main ${PWD}

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -9,7 +9,7 @@ image_resource:
 
 inputs:
 - name: cf-deployment-concourse-tasks  # - This repo
-- name: bbl-state  # - The Director's `bbl-state.json`
+- name: bbl-state  # - The Director's bbl state dir
 - name: ops-files
 # - A directory containing ops files
 #   to be specifed with the `OPS_FILES` param

--- a/bosh-delete-deployment/task.yml
+++ b/bosh-delete-deployment/task.yml
@@ -8,7 +8,7 @@ image_resource:
     tag: v3.15.0
 
 inputs:
-- name: bbl-state  # - The Director's `bbl-state.json`
+- name: bbl-state  # - The Director's bbl state dir
 - name: cf-deployment-concourse-tasks  # - This repo
 
 run:

--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -8,7 +8,7 @@ image_resource:
     tag: v3.15.0
 
 inputs:
-- name: bbl-state  # - The Director's `bbl-state.json`
+- name: bbl-state  # - The Director's bbl state dir
 - name: cf-deployment  # - The cf-deployment manifest
 - name: vars-store  # - The BOSH deployment's vars-store yaml file
 - name: ops-files  # - Operations files to be made available

--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -8,7 +8,7 @@ image_resource:
     tag: v3.15.0
 
 inputs:
-- name: bbl-state  # - The Director's `bbl-state.json`
+- name: bbl-state  # - The Director's bbl state dir
 - name: cf-deployment  # - The cf-deployment manifest
 - name: vars-store  # - The BOSH deployment's vars-store yaml file
 - name: ops-files  # - Operations files to be made available

--- a/bosh-upload-stemcell-from-cf-deployment/task.yml
+++ b/bosh-upload-stemcell-from-cf-deployment/task.yml
@@ -10,7 +10,7 @@ image_resource:
 inputs:
 - name: cf-deployment-concourse-tasks  # - This repo
 - name: cf-deployment  # - The cf-deployment manifest
-- name: bbl-state  # - The Director's `bbl-state.json`
+- name: bbl-state  # - The Director's bbl state dir
 
 run:
   path: cf-deployment-concourse-tasks/bosh-upload-stemcell-from-cf-deployment/task


### PR DESCRIPTION
`bbl` now writes multiple files to the state directory, including terraform templates and state, vars-store files, create and delete env scripts, and manifests and ops files for the director and jumpbox. Since some of these files hold state which was formerly present in `bbl-state.json`, they should be tracked by Git as part of the user's bbl states repo.

cc: @desmondrawls @evanfarrar