### PR TITLE
Add ability to deploy a concourse-deployment manifest

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -126,7 +126,7 @@ function main() {
     bbl \
       --debug \
       create-lbs \
-      --type=cf \
+      --type="${BBL_LB_TYPE}" \
       --cert="${bbl_cert_path}" \
       ${bbl_cert_chain_flag} \
       --key="${bbl_key_path}" \

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -5,8 +5,18 @@ source cf-deployment-concourse-tasks/shared-functions
 
 function check_fast_fails() {
   set +x
-  if [ -z "${LB_DOMAIN}" ]; then
-    echo "\$LB_DOMAIN is a required parameter.  Please set the domain."
+  if [ "${BBL_LB_TYPE}" != "cf" ] && [ "${BBL_LB_TYPE}" != "concourse" ]; then
+    echo "\$BBL_LB_TYPE must be one of [cf, concourse]."
+    exit 1
+  fi
+
+  if [ -z "${LB_DOMAIN}" ] && [ "${BBL_LB_TYPE}" == "cf" ]; then
+    echo "\$LB_DOMAIN is a required parameter when \$BBL_LB_TYPE=cf.  Please set the domain."
+    exit 1
+  fi
+
+  if [ -n "${LB_DOMAIN}" ] && [ "${BBL_LB_TYPE}" == "concourse" ]; then
+    echo "\$LB_DOMAIN should not be set when \$BBL_LB_TYPE=concourse."
     exit 1
   fi
 
@@ -114,7 +124,11 @@ function main() {
     fi
 
     local domain_flag
-    domain_flag="--domain=${LB_DOMAIN}"
+    domain_flag=""
+
+    if [ -n "${LB_DOMAIN}" -a ! -f bbl-state.json ]; then
+      domain_flag="--domain=${LB_DOMAIN}"
+    fi
 
     if [ "${BBL_IAAS}" == "gcp" ]; then
       write_service_account_key

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -96,6 +96,12 @@ function main() {
   local root_dir
   root_dir="${1}"
 
+  create_lbs=false
+
+  if [ "${IS_BOSH_LITE}" == "false" ] && [ "${SKIP_LB_CREATION}" == "false" ]; then
+    create_lbs=true
+  fi
+
   check_fast_fails
 
   local ops_arguments
@@ -108,12 +114,6 @@ function main() {
 
   mkdir -p "bbl-state/${BBL_STATE_DIR}"
   pushd "bbl-state/${BBL_STATE_DIR}"
-    local bbl_cert_chain_flag
-    bbl_cert_chain_flag=""
-    local bbl_cert_path
-    local bbl_cert_key
-    write_bbl_certs
-
     bbl version
 
     local name_flag
@@ -134,17 +134,30 @@ function main() {
       write_service_account_key
     fi
 
-    bbl --debug up ${name_flag} ${ops_arguments} ${BBL_EXTRA_FLAGS} > "${root_dir}/bbl_up.txt"
+    local lb_flags
+    lb_flags=""
 
-    # The two commands below amount to "create or update"
-    bbl \
-      --debug \
-      create-lbs \
-      --type="${BBL_LB_TYPE}" \
-      --cert="${bbl_cert_path}" \
-      ${bbl_cert_chain_flag} \
-      --key="${bbl_key_path}" \
-      ${domain_flag} > "${root_dir}/bbl_create_lbs.txt"
+    if [ "${create_lbs}" == "true" ]; then
+      local bbl_cert_chain_flag
+      bbl_cert_chain_flag=""
+      local bbl_cert_path
+      local bbl_cert_key
+      write_bbl_certs
+
+      lb_flags="--lb-type=cf --lb-cert=${bbl_cert_path} ${bbl_cert_chain_flag} --lb-key=${bbl_key_path} --lb-domain=${LB_DOMAIN}"
+    fi
+
+    bbl plan \
+      ${name_flag} \
+      ${ops_arguments} \
+      ${lb_flags} \
+      ${BBL_EXTRA_FLAGS} > "${root_dir}/bbl_plan.txt"
+
+    bbl --debug up \
+      ${name_flag} \
+      ${lb_flags} \
+      ${ops_arguments} \
+      ${BBL_EXTRA_FLAGS} > "${root_dir}/bbl_up.txt"
 
   popd
 }

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -55,6 +55,10 @@ params:
   # - The target IAAS which bbl will create infrastructure
   # - Must be either `aws` or `gcp`
 
+  BBL_LB_TYPE: cf
+  # - Optional
+  # - `cf` or `concourse`
+
   BBL_LB_CERT:
   # - Required
   # - PEM encoded certificate to be associated with the load balancer

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -81,7 +81,7 @@ params:
   # - If a path is provided, path is relative to the `bbl-state` input
 
   LB_DOMAIN:
-  # - Required
+  # - Required if BBL_LB_TYPE=cf
   # - The domain which bbl will register
 
   BBL_ENV_NAME:

--- a/bosh-upload-stemcell-from-cf-deployment/task
+++ b/bosh-upload-stemcell-from-cf-deployment/task
@@ -27,9 +27,9 @@ function check_upload_stemcell_params() {
 function upload_stemcell() {
   # Read potentially variable stemcell paramaters out of cf-deployment with bosh
   local os
-  os=$(bosh interpolate --path=/stemcells/alias=default/os cf-deployment/cf-deployment.yml)
+  os=$(bosh interpolate --path=/stemcells/alias=default/os cf-deployment/${MANIFEST_FILE})
   local version
-  version=$(bosh interpolate --path=/stemcells/alias=default/version cf-deployment/cf-deployment.yml)
+  version=$(bosh interpolate --path=/stemcells/alias=default/version cf-deployment/${MANIFEST_FILE})
 
   # Hardcode a couple of stable stemcell paramaters
   local stemcells_url

--- a/bosh-upload-stemcell-from-cf-deployment/task.yml
+++ b/bosh-upload-stemcell-from-cf-deployment/task.yml
@@ -46,3 +46,8 @@ params:
   BBL_GCP_SERVICE_ACCOUNT_KEY:
   # - Key content or path to the file containing credentials downloaded from GCP
   # - Path is relative to the BBL_STATE_DIR specified a
+
+  MANIFEST_FILE: cf-deployment.yml
+  # - Required
+  # - Filepath to the manifest file within the cf-deployment resource
+  # - The path is relative to root of the `cf-deployment` input


### PR DESCRIPTION
These changes allow cf-deployment-concourse-tasks to deploy another manifest like this one: https://github.com/evanfarrar/concourse-deployment

Main changes:

- Add `BBL_LB_TYPE` (default to `cf`, can set to `concourse`).
   - Only set the `domain` flag when type=cf.
- Add `MANIFEST_FILE` param to `upload-stemcell` task.
