### PR TITLE
Add ability to use 'latest' stemcell version

### DIFF
--- a/bosh-upload-stemcell-from-cf-deployment/task
+++ b/bosh-upload-stemcell-from-cf-deployment/task
@@ -60,7 +60,11 @@ function upload_stemcell() {
   fi
 
   stemcell_name="${stemcell_name}-${os}-${bosh_agent}"
-  full_stemcell_url="${stemcells_url}/${stemcell_name}?v=${version}"
+  if [ "$version" = "latest" ]; then
+    full_stemcell_url="${stemcells_url}/${stemcell_name}"
+  else
+    full_stemcell_url="${stemcells_url}/${stemcell_name}?v=${version}"
+  fi
 
   # If bosh already has our stemcell, exit 0
   if [ "${existing_stemcell}" ]; then


### PR DESCRIPTION
This allows this task to work with manifests that use `version: latest` for the stemcell, like [this one](https://github.com/evanfarrar/concourse-deployment/blob/ab29b5ad6d808e9126066241fdf51206099370aa/concourse-deployment.yml#L17).

