### PR TITLE
don't try to copy the .bbl directory

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -111,7 +111,6 @@ function main() {
         ${BBL_EXTRA_FLAGS} > "${root_dir}/bbl_plan.txt"
 
       cp -r /var/repos/bosh-bootloader/plan-patches/bosh-lite-gcp/* .
-      cp -r /var/repos/bosh-bootloader/plan-patches/bosh-lite-gcp/.bbl .
 
       bbl --debug up \
         ${name_flag} \


### PR DESCRIPTION
[it isn't there anymore](https://github.com/cloudfoundry/bosh-bootloader/tree/master/plan-patches/bosh-lite-gcp)

- commit that removed it: https://github.com/cloudfoundry/bosh-bootloader/commit/e7eb1d2de937c2d963fc16b4808fa88a0781693d
- story that removed it: [#153194965](https://www.pivotaltracker.com/n/projects/1488988/stories/153194965)