### PR TITLE
Added ability to add customisation scripts for terraform

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -125,6 +125,12 @@ function main() {
       cp -r /var/repos/bosh-bootloader/plan-patches/bosh-lite-gcp/* .
     fi
 
+    if [ -n "${BBL_CUSTOMISATIONS}" ]; then
+      for CUSTOMISATION in ${BBL_CUSTOMISATIONS}; do
+        cp ${root_dir}/bbl-customisations/${CUSTOMISATION} terraform/
+      done
+    fi 
+
     bbl --debug up \
       ${name_flag} \
       ${lb_flags} \

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -17,7 +17,9 @@ inputs:
 #   we suggest you use `input_mapping`
 #   to map your `env-repo` resource to `ops-files`
 #   in order to satisfy this required input.
-
+- name: bbl-customisations
+# - A directory containing a list of extra terraform
+#   scripts to be applied with bbl
 outputs:
 - name: updated-env-repo
 # - The env-repo resource, with changes git committed,
@@ -86,6 +88,12 @@ params:
   # - Optional
   # - Extra flags to pass into bbl up
   # - Can be used for experimental features such as `--credhub`
+
+  BBL_CUSTOMISATIONS:
+  # - Optional
+  # - a list of terraform customisations to be added to bbl
+  # - Files will be added to the terraform directory before the
+  # - plan is applied.
 
   GIT_COMMIT_EMAIL:
   GIT_COMMIT_USERNAME:


### PR DESCRIPTION
This PR adds the ability to apply extra terraform scripts when performing a bbl up.  This is useful when using those scripts to provision extra infrastructure such as nat-gateways, cloud sql instances etc.