### PR TITLE
Add log-cache-cli to Dockerfile

### DIFF
--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -94,6 +94,10 @@ RUN \
   mkdir ${GOPATH} && \
   rm -rf /tmp/*
 
+# Log Cache CLI
+RUN go get -u code.cloudfoundry.org/log-cache-cli && \
+    cf install-plugin ${GOPATH}/bin/log-cache-cli -f
+
 RUN go get -u github.com/cloudfoundry/uptimer && \
   go get -u github.com/onsi/ginkgo/... && \
   cd ${GOPATH}/src/github.com/cloudfoundry/uptimer && \


### PR DESCRIPTION
This PR adds the log-cache-cli CF plugin to the Dockerfile so that it can be used with CATs.