### PR TITLE
Correct VARS_STORE_FILE description

### DIFF
--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -36,7 +36,7 @@ params:
   # - The path is relative to root of the `cf-deployment` input
 
   VARS_STORE_FILE: deployment-vars.yml
-  # - Required
+  # - Required (with default) unless USE_VARS_STORE is `false`
   # - Filepath to the BOSH deployment vars-store yaml file
   # - The path is relative to root of the `vars-store` input
 


### PR DESCRIPTION
A [question in slack](https://cloudfoundry.slack.com/archives/C2U7KA7M4/p1531247320000385) brought it to my attention
that this description wasn't,
perhaps,
updated when the option to not use a vars store was added.

Here's the code for the behavior this change describes:
https://github.com/cloudfoundry/cf-deployment-concourse-tasks/blob/afc0d171fd44543a138133b909e5375b4db8f44a/shared-functions#L103-L107

I've only corrected this here, other tasks with similar parameters
may have the same issue.