### PR TITLE
set use_single_app_instance config through env var

### DIFF
--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -117,5 +117,8 @@ params:
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for app syslog availability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+
   USE_SINGLE_APP_INSTANCE: false
   # - Optional
+  # - Configures uptimer to deploy with a single app instance rather than two.
+  # - This is primarily used by Diego to validate new uptime features.

--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -117,3 +117,5 @@ params:
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for app syslog availability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+  USE_SINGLE_APP_INSTANCE: false
+  # - Optional

--- a/bosh-deploy-with-updated-release-submodule/task.yml
+++ b/bosh-deploy-with-updated-release-submodule/task.yml
@@ -111,5 +111,8 @@ params:
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for app syslog availability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+
   USE_SINGLE_APP_INSTANCE: false
   # - Optional
+  # - Configures uptimer to deploy with a single app instance rather than two.
+  # - This is primarily used by Diego to validate new uptime features.

--- a/bosh-deploy-with-updated-release-submodule/task.yml
+++ b/bosh-deploy-with-updated-release-submodule/task.yml
@@ -111,3 +111,5 @@ params:
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for app syslog availability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+  USE_SINGLE_APP_INSTANCE: false
+  # - Optional

--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -104,3 +104,5 @@ params:
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for app syslog availability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+  USE_SINGLE_APP_INSTANCE: false
+  # - Optional

--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -104,5 +104,8 @@ params:
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for app syslog availability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+
   USE_SINGLE_APP_INSTANCE: false
   # - Optional
+  # - Configures uptimer to deploy with a single app instance rather than two.
+  # - This is primarily used by Diego to validate new uptime features.

--- a/shared-functions
+++ b/shared-functions
@@ -135,9 +135,6 @@ write_uptimer_deploy_config() {
   local available_port
   available_port=${AVAILABLE_PORT:-"-1"}
 
-  if [ -z "${USE_SINGLE_APP_INSTANCE}" ]; then
-    USE_SINGLE_APP_INSTANCE=false
-  fi
   set +x
   local cf_admin_password
 

--- a/shared-functions
+++ b/shared-functions
@@ -135,9 +135,17 @@ write_uptimer_deploy_config() {
   local available_port
   available_port=${AVAILABLE_PORT:-"-1"}
 
+  if [ -z "${USE_SINGLE_APP_INSTANCE}" ]; then
+    USE_SINGLE_APP_INSTANCE=false
+  fi
   set +x
   local cf_admin_password
-  cf_admin_password=$(get_password_from_credhub cf_admin_password)
+
+  if [ -z "${CF_ADMIN_PASSWORD}" ]; then
+     cf_admin_password=$(get_password_from_credhub cf_admin_password)
+  else
+    cf_admin_password=$(echo ${CF_ADMIN_PASSWORD})
+  fi
 
   echo '{}' | jq --arg cf_api api.${SYSTEM_DOMAIN} \
     --arg admin_password ${cf_admin_password} \
@@ -151,6 +159,7 @@ write_uptimer_deploy_config() {
     --arg http_availability ${HTTP_AVAILABILITY_THRESHOLD} \
     --arg recent_logs ${RECENT_LOGS_THRESHOLD} \
     --arg streaming_logs ${STREAMING_LOGS_THRESHOLD} \
+    --arg use_single_app_instance ${USE_SINGLE_APP_INSTANCE} \
     --arg app_syslog_availability ${APP_SYSLOG_AVAILABILITY_THRESHOLD} \
     '{
       "while": [{
@@ -163,7 +172,8 @@ write_uptimer_deploy_config() {
         "admin_user": "admin",
         "admin_password": $admin_password,
         "tcp_domain": $tcp_domain,
-        "available_port": $available_port | tonumber
+        "available_port": $available_port | tonumber,
+        "use_single_app_instance": $use_single_app_instance | ascii_downcase | contains("true")
       },
       "allowed_failures": {
         "app_pushability": $app_pushability | tonumber,

--- a/shared-functions
+++ b/shared-functions
@@ -138,11 +138,7 @@ write_uptimer_deploy_config() {
   set +x
   local cf_admin_password
 
-  if [ -z "${CF_ADMIN_PASSWORD}" ]; then
-     cf_admin_password=$(get_password_from_credhub cf_admin_password)
-  else
-    cf_admin_password=$(echo ${CF_ADMIN_PASSWORD})
-  fi
+  cf_admin_password=$(get_password_from_credhub cf_admin_password)
 
   echo '{}' | jq --arg cf_api api.${SYSTEM_DOMAIN} \
     --arg admin_password ${cf_admin_password} \


### PR DESCRIPTION
Modified the shared-functions to use a given password and not credhub
Changes to be less diego specific