### PR TITLE
Update config task to use credhub_admin_client_secret

### DIFF
--- a/update-integration-configs/task
+++ b/update-integration-configs/task
@@ -53,7 +53,7 @@ function main() {
     local new_cats_integration_config
     new_cats_integration_config=$(cat "integration-configs/${CATS_INTEGRATION_CONFIG_FILE}" | jq ".admin_password=\"${admin_password}\"")
 
-    local credhub_secret=$(get_password_from_credhub uaa_clients_cc_service_key_client_secret)
+    local credhub_secret=$(get_password_from_credhub credhub_admin_client_secret)
     new_cats_integration_config=$(echo "${new_cats_integration_config}" | jq ".credhub_secret=\"${credhub_secret}\"")
 
     if [ -n "${SYSTEM_DOMAIN}" ]; then


### PR DESCRIPTION
We created a PR in cf-deployment(https://github.com/cloudfoundry/cf-deployment/pull/580) and cf-acceptance tests(https://github.com/cloudfoundry/cf-acceptance-tests/pull/321) to add a UAA credhub_admin_client that has the proper credhub permissions for creating and reading credentials in cf-acceptance tests. This just updates the config to use the credhub_admin_client instead of the cc_service_key_client.   

Signed-off-by: Anna Thornton <athornton@pivotal.io>