### PR TITLE
Update-integration-configs should not fail if only a wats config is provided

### DIFF
--- a/update-integration-configs/task
+++ b/update-integration-configs/task
@@ -5,8 +5,8 @@ set -o pipefail
 source cf-deployment-concourse-tasks/shared-functions
 
 function check_fast_fails() {
-  if [ ! -f "integration-configs/$CATS_INTEGRATION_CONFIG_FILE" -a ! -f "integration-configs/$RATS_INTEGRATION_CONFIG_FILE" ]; then
-    echo "Neither cats_integration_config file nor rats_integration_config file is present...Exiting"
+  if [ ! -f "integration-configs/$CATS_INTEGRATION_CONFIG_FILE" -a ! -f "integration-configs/$RATS_INTEGRATION_CONFIG_FILE" -a ! -f "integration-configs/$WATS_INTEGRATION_CONFIG_FILE" ]; then
+    echo "One of the following files should be present, but none were found: cats_integration_config, rats_integration_config, wats_integration_config. Exiting."
     exit 1
   fi
 }


### PR DESCRIPTION
The Diego team has an environment that includes both windows2012 and windows2016 cells. When we upgrade our integration configs, we actually want to update two WATs configs, one for each kind of windows cell. Since the interface of the task only allows the update of a single WATs config, we run the task an extra time and that one only updates the WATs 2016 config. That task was getting an error because this validation assumes that you have either a CATs or RATs config also being updated.