### PR TITLE
Extend bosh deploy by optional arguments

### DIFF
--- a/bosh-deploy-with-created-release/task
+++ b/bosh-deploy-with-created-release/task
@@ -36,7 +36,7 @@ main() {
     remove_credentials_from_credhub
   fi
   bosh_update_dns_runtime_config
-  bosh_deploy
+  bosh_deploy ${BOSH_DEPLOY_ARGS}
 }
 
 main "${PWD}"

--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -122,3 +122,7 @@ params:
   # - Optional
   # - Configures uptimer to deploy with a single app instance rather than two.
   # - This is primarily used by Diego to validate new uptime features.
+
+  BOSH_DEPLOY_ARGS:
+  # - Optional
+  # - Supplies additional arguments to the bosh deploy command

--- a/shared-functions
+++ b/shared-functions
@@ -226,7 +226,8 @@ function bosh_deploy() {
         -n \
         -d "${deployment_name}" \
         deploy \
-        "${INTERPOLATED_MANIFEST}"
+        "${INTERPOLATED_MANIFEST}" \
+        ${@}
     popd
   fi
 }


### PR DESCRIPTION
[#159780275]

Signed-off-by: Slawek Ligus <sligus@pivotal.io>

We had the need to recreate/repave our deployment. This allows for optional bosh deploy args when deploying.