### PR TITLE
Add option to configure keep-alive when running errand

### DIFF
--- a/run-errand/task
+++ b/run-errand/task
@@ -19,7 +19,13 @@ function main() {
   check_input_params
   setup_bosh_env_vars
 
-  bosh -d "${DEPLOYMENT_NAME}" run-errand "${ERRAND_NAME}"
+  PARAMS=""
+
+  if [ "$KEEP_ALIVE" = true ]; then
+    PARAMS="$PARAMS --keep-alive"
+  fi
+
+  bosh -d "${DEPLOYMENT_NAME}" run-errand "${ERRAND_NAME}" $PARAMS
 }
 
 main

--- a/run-errand/task.yml
+++ b/run-errand/task.yml
@@ -18,3 +18,4 @@ params:
   BBL_STATE_DIR: bbl-state
   DEPLOYMENT_NAME: cf
   ERRAND_NAME:
+  KEEP_ALIVE: false


### PR DESCRIPTION
Added support to allow extra parameters to be added in the future.

Paired with @aclevername