### PR TITLE
Add --keep-alive option to run-errand

### DIFF
--- a/run-errand/task
+++ b/run-errand/task
@@ -19,7 +19,12 @@ function main() {
   check_input_params
   setup_bosh_env_vars
 
-  bosh -d "${DEPLOYMENT_NAME}" run-errand "${ERRAND_NAME}"
+  local arguments=''
+  if [ "$KEEP_ALIVE" == "true" ]; then
+    arguments="${arguments} --keep-alive"
+  fi
+
+  bosh -d "${DEPLOYMENT_NAME}" run-errand ${arguments} "${ERRAND_NAME}"
 }
 
 main

--- a/run-errand/task.yml
+++ b/run-errand/task.yml
@@ -18,3 +18,4 @@ params:
   BBL_STATE_DIR: bbl-state
   DEPLOYMENT_NAME: cf
   ERRAND_NAME:
+  KEEP_ALIVE: false


### PR DESCRIPTION
Utilizes the bosh run-errand --keep-alive feature which does not tear
down the errand VM every time the errand is run

Defaulted in task config to false and can be enabled by setting the
KEEP_ALIVE parameter to true