### PR TITLE
Extract `git status` to a variable

### DIFF
--- a/shared-functions
+++ b/shared-functions
@@ -40,7 +40,8 @@ function commit_bbl_state_dir {
   commit_message="${2}"
 
   pushd "${root_dir}/bbl-state/${BBL_STATE_DIR}"
-    if [[ -n $(git status --porcelain) ]]; then
+    status="$(git status --porcelain)"
+    if [[ -n "$status" ]]; then
       set_git_config
       git add --all .
       git commit -m "${commit_message}"


### PR DESCRIPTION
In special circumstances, such as when using git-crypt and running this task in a [older version of concourse](https://github.com/concourse/git-resource/commit/648fd8794f5c874e2ef44a92cb87cd29c51d4e5f), git status can fail. 

Even though we have `-e`, when we wrap commands in `if` statements like this, the expression be evaluated but no checking will be made on the exit code.

Extracting the output of `git status` to a variable will ensure we are testing not only the output, but also exiting when it fails.