### PR TITLE
Added netcat-openbsd to the base container

### DIFF
--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -25,6 +25,7 @@ RUN \
     libxml2-dev \
     libxslt-dev \
     libyaml-dev \
+    netcat-openbsd \
     openssl \
     software-properties-common \
     sqlite \


### PR DESCRIPTION
The cf-deployment-concourse-tasks docker container is useful as a container to operate your environment by mounting the bbl-state in and evaluating it. However recently you're unable to bosh ssh into any instances using the most recent version as `nc` is not installed. By installing the `netcat-openbsd` (_see https://github.com/cloudfoundry/bosh-cli/issues/328#issuecomment-344052164_) package you're able to bosh ssh into vms.