### PR TITLE
More debug output

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -87,17 +87,24 @@ function main() {
       lb_flags="--lb-type=cf --lb-cert=${bbl_cert_path} ${bbl_cert_chain_flag} --lb-key=${bbl_key_path} --lb-domain=${LB_DOMAIN}"
     fi
 
-    bbl plan --debug \
+    local drain
+    drain=">"
+
+    if [ "${DEBUG_MODE}" == "true" ] ; then
+      drain="| tee"
+    fi
+
+    eval bbl plan --debug \
       ${name_flag} \
-      ${lb_flags} | tee "${root_dir}/bbl_plan.log"
+      ${lb_flags} ${drain} "${root_dir}/bbl_plan.log"
 
     if [ -n "${BBL_CONFIG_DIR}" ]; then
       cp -r ${root_dir}/bbl-config/${BBL_CONFIG_DIR}/. .
     fi
 
-    bbl --debug up \
+    eval bbl --debug up \
       ${name_flag} \
-      ${lb_flags} | tee "${root_dir}/bbl_up.log"
+      ${lb_flags} ${drain} "${root_dir}/bbl_up.log"
   popd
 }
 

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -89,7 +89,7 @@ function main() {
 
     bbl plan --debug \
       ${name_flag} \
-      ${lb_flags} > "${root_dir}/bbl_plan.log"
+      ${lb_flags} | tee "${root_dir}/bbl_plan.log"
 
     if [ -n "${BBL_CONFIG_DIR}" ]; then
       cp -r ${root_dir}/bbl-config/${BBL_CONFIG_DIR}/. .
@@ -97,7 +97,7 @@ function main() {
 
     bbl --debug up \
       ${name_flag} \
-      ${lb_flags} > "${root_dir}/bbl_up.log"
+      ${lb_flags} | tee "${root_dir}/bbl_up.log"
   popd
 }
 

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -87,9 +87,9 @@ function main() {
       lb_flags="--lb-type=cf --lb-cert=${bbl_cert_path} ${bbl_cert_chain_flag} --lb-key=${bbl_key_path} --lb-domain=${LB_DOMAIN}"
     fi
 
-    bbl plan \
+    bbl plan --debug \
       ${name_flag} \
-      ${lb_flags} > "${root_dir}/bbl_plan.txt"
+      ${lb_flags} > "${root_dir}/bbl_plan.log"
 
     if [ -n "${BBL_CONFIG_DIR}" ]; then
       cp -r ${root_dir}/bbl-config/${BBL_CONFIG_DIR}/. .
@@ -97,7 +97,7 @@ function main() {
 
     bbl --debug up \
       ${name_flag} \
-      ${lb_flags} > "${root_dir}/bbl_up.txt"
+      ${lb_flags} > "${root_dir}/bbl_up.log"
   popd
 }
 

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -105,3 +105,9 @@ params:
   # - Optional
   # - Set to `true` to skip load balancer creation,
   # - for example, a BOSH Lite environment
+
+  DEBUG_MODE: false
+  # - Optional
+  # - With `false` all output from BBL calls will be saved in log files inside concourse job only.
+  # - Set this to `true` to see all output straight in the pipeline.
+  # - Be careful. For public pipelines it can cause credentials disclosure.


### PR DESCRIPTION
### What is this change about?

This change add more debug output to `bbl-up` task.

### Please provide contextual information.

I love to use this tool for deploying CloudFoundry. However, as an engineer, I definitely need to understand what is going on when I trigger the job. Without a debug output I'm acting like a blind. Moreover, Concourse destroys containers after successful deployment, so I will not be able to troubleshoot anything in future, because `bbl-up.txt` will gone within container.


### Please check all that apply for this PR:
- [ ] changes an existing task


### Did you update the README as appropriate for this change?
- [ ] N/A



### How should this change be described in release notes?

n/a



### What is the level of urgency for publishing this change?

- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
n/a