### PR TITLE
More debug

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -87,6 +87,7 @@ function main() {
       lb_flags="--lb-type=cf --lb-cert=${bbl_cert_path} ${bbl_cert_chain_flag} --lb-key=${bbl_key_path} --lb-domain=${LB_DOMAIN}"
     fi
 
+    set -o pipefail
     local drain
     drain=">"
 
@@ -105,8 +106,6 @@ function main() {
     eval bbl --debug up \
       ${name_flag} \
       ${lb_flags} ${drain} "${root_dir}/bbl_up.log"
-    echo $?
-    echo $-
   popd
 }
 

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -97,7 +97,7 @@ function main() {
 
     eval bbl plan --debug \
       ${name_flag} \
-      ${lb_flags} ${drain} "${root_dir}/bbl_plan.log"
+      ${lb_flags} 2>&1 ${drain} "${root_dir}/bbl_plan.log"
 
     if [ -n "${BBL_CONFIG_DIR}" ]; then
       cp -r ${root_dir}/bbl-config/${BBL_CONFIG_DIR}/. .
@@ -105,7 +105,7 @@ function main() {
 
     eval bbl --debug up \
       ${name_flag} \
-      ${lb_flags} ${drain} "${root_dir}/bbl_up.log"
+      ${lb_flags} 2>&1 ${drain} "${root_dir}/bbl_up.log"
   popd
 }
 

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -105,6 +105,8 @@ function main() {
     eval bbl --debug up \
       ${name_flag} \
       ${lb_flags} ${drain} "${root_dir}/bbl_up.log"
+    echo $?
+    echo $-
   popd
 }
 

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -97,7 +97,7 @@ function main() {
 
     eval bbl plan --debug \
       ${name_flag} \
-      ${lb_flags} 2>&1 ${drain} "${root_dir}/bbl_plan.log"
+      ${lb_flags} "2>&1" ${drain} "${root_dir}/bbl_plan.log"
 
     if [ -n "${BBL_CONFIG_DIR}" ]; then
       cp -r ${root_dir}/bbl-config/${BBL_CONFIG_DIR}/. .
@@ -105,7 +105,7 @@ function main() {
 
     eval bbl --debug up \
       ${name_flag} \
-      ${lb_flags} 2>&1 ${drain} "${root_dir}/bbl_up.log"
+      ${lb_flags} "2>&1" ${drain} "${root_dir}/bbl_up.log"
   popd
 }
 


### PR DESCRIPTION
Hi!
This is a quick follow-up for #84 
I just realized that it not working as expected, because `tee` aways has successful exit status, so pipeline never fails.
This fix is for catching a real status from `bbl` call.
Sorry for not foreseeing this issue before.