### PR TITLE
Add instance flag to run-errand task

### DIFF
--- a/run-errand/task
+++ b/run-errand/task
@@ -25,7 +25,11 @@ function main() {
     PARAMS="$PARAMS --keep-alive"
   fi
 
-  bosh -d "${DEPLOYMENT_NAME}" run-errand "${ERRAND_NAME}" $PARAMS
+  if [ -n "${INSTANCE}" ]; then
+    PARAMS="${PARAMS} --instance=${INSTANCE}"
+  fi
+
+  bosh -d "${DEPLOYMENT_NAME}" run-errand "${ERRAND_NAME}" ${PARAMS}
 }
 
 main

--- a/run-errand/task.yml
+++ b/run-errand/task.yml
@@ -18,4 +18,5 @@ params:
   BBL_STATE_DIR: bbl-state
   DEPLOYMENT_NAME: cf
   ERRAND_NAME:
+  INSTANCE:
   KEEP_ALIVE: false


### PR DESCRIPTION
### What is this change about?

This PR adds an `INSTANCE` parameter to the `run-errand` task. It is required to allow CI jobs to disambiguate between different-configured copies of the same errand job within a deployment. For the Diego Persistence team, we test our `nfsbrokerpush` errand with different configuration for the backing store used by the NFS broker application. This change allows us to specify which instance of the errand should be run.

### Please provide contextual information.

[#161974894](https://www.pivotaltracker.com/story/show/161974894)

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A - the `run-errand` task is not referenced in the README

### How should this change be described in release notes?

Updated Tasks:
* `run-errand`
  * Added parameterized support for specifying the instance that should be used to run an errand.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@paulcwarren @juluan-hj