### PR TITLE
Add task to delete all bosh deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ running out of space.
 
 ### [bosh-delete-deployment][bosh-delete-deployment-task-yaml]
 This deletes a BOSH deployment.
+If you want to delete all of the available BOSH deployments you can set the `DELETE_ALL_DEPLOYMENTS` flag to `true`.
 
 ### [bosh-deploy][bosh-deploy-task-yaml]
 This performs a BOSH upload-stemcell and BOSH deployment.

--- a/bosh-delete-deployment/task
+++ b/bosh-delete-deployment/task
@@ -4,6 +4,21 @@ set -exu
 # shellcheck disable=SC1091
 source cf-deployment-concourse-tasks/shared-functions
 
+function bosh_delete_all_deployments() {
+    local deployments
+    deployments=$(bosh deployments --json | jq -r '.Tables[].Rows[].name')
+
+    for deployment in ${deployments}; do
+      if [ -n "${deployment}" ]; then
+        echo "Deleting deployment: ${deployment}"
+      	bosh \
+          -n \
+        	delete-deployment -d "${deployment}" \
+      		${force_flag}
+    	fi
+    done
+}
+
 function check_delete_deployment_params() {
   if [ -z "$DEPLOYMENT_NAME" ]; then
     echo "DEPLOYMENT_NAME has not been set"
@@ -25,9 +40,13 @@ function bosh_delete_deployment() {
 }
 
 function main() {
-  check_delete_deployment_params
   setup_bosh_env_vars
-  bosh_delete_deployment
+  if [ "$DELETE_ALL_DEPLOYMENTS" = true ]; then
+    bosh_delete_all_deployments
+  else
+    check_delete_deployment_params
+    bosh_delete_deployment
+  fi
 }
 
 main

--- a/bosh-delete-deployment/task.yml
+++ b/bosh-delete-deployment/task.yml
@@ -21,6 +21,10 @@ params:
   # - If blank or '.', uses `bbl-state` input as the location for bbl state
   # - If the specified path does not exist, it will be created
 
+  DELETE_ALL_DEPLOYMENTS: false
+  # - Optional
+  # - When true, deletes ALL BOSH deployments
+
   DEPLOYMENT_NAME: cf
 
   IGNORE_ERRORS: false


### PR DESCRIPTION
### What is this change about?

Its a task to delete all bosh deployments, so that we can delete the deployments without needing to specify the deployment names.

We are adding pipelines to bbl-up our existing environments and bbl-down any environments that we might someday need to destroy. As part of destroying these environments, we may have to delete the bosh deployments and we may not know the names of those bosh deployments. We created this script to do just that and thought it might be of use here!

### Please check all that apply for this PR:
- [x] introduces a new task
- [ ] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)


### Did you update the README as appropriate for this change?
- [x] YES
- [ ] N/A


### How should this change be described in release notes?

* bosh-delete-all-deployments - delete all bosh deployments

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!
@genevieve #pcf-windows and #garden-windows
