### PR TITLE
Add support for --lb-type through BBL_LB_TYPE

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -6,7 +6,7 @@ source cf-deployment-concourse-tasks/shared-functions
 function check_fast_fails() {
   set +x
 
-  if [ "${SKIP_LB_CREATION}" == "false" ]; then
+  if [[ "${SKIP_LB_CREATION}" == "false" && "${BBL_LB_TYPE}" == "cf" ]]; then
     if [ -z "${LB_DOMAIN}" ]; then
       echo "\$LB_DOMAIN is a required parameter.  Please set the domain."
       exit 1
@@ -77,7 +77,7 @@ function main() {
     local lb_flags
     lb_flags=""
 
-    if [ "${SKIP_LB_CREATION}" == "false" ]; then
+    if [[ "${SKIP_LB_CREATION}" == "false" && "${BBL_LB_TYPE}" == "cf" ]]; then
       local bbl_cert_chain_flag
       bbl_cert_chain_flag=""
       local bbl_cert_path
@@ -85,6 +85,8 @@ function main() {
       write_bbl_certs
 
       lb_flags="--lb-type=cf --lb-cert=${bbl_cert_path} ${bbl_cert_chain_flag} --lb-key=${bbl_key_path} --lb-domain=${LB_DOMAIN}"
+    elif [[ "${SKIP_LB_CREATION}" == "false" && -n "${BBL_LB_TYPE}" ]]; then
+      lb_flags="--lb-type=${BBL_LB_TYPE}"
     fi
 
     set -o pipefail

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -89,6 +89,12 @@ params:
   # - Required if `SKIP_LB_CREATION` is false
   # - The domain which bbl will register
 
+  BBL_LB_TYPE: cf
+  # - Optional
+  # - The type of Load Balancer bbl should create
+  # - Only used if `SKIP_LB_CREATION` is false
+  # - Must be `cf` or `concourse`
+
   BBL_ENV_NAME:
   # - Optional
   # - A label to apply to the bbl environment


### PR DESCRIPTION
- Allows users to set `concourse` lb type to bbl up environments for concourse

### What is this change about?

This allows users to change their load balancer type to `concourse` if using `bbl-up` task to deploy Concourse.

### Please provide contextual information.

Needed for [#165162223](https://www.pivotaltracker.com/story/show/165162223)

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [ ] N/A



### How should this change be described in release notes?

bbl-up task allows support for different Load Balancer types though `BBL_LB_TYPE`.



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
