### PR TITLE
Add ability to store bbl-state in S3/GCS as a tarball

### DIFF
--- a/bbl-destroy/task
+++ b/bbl-destroy/task
@@ -27,6 +27,10 @@ function main() {
   popd
 }
 
-trap "commit_bbl_state_dir ${PWD} 'Remove bbl state dir'" EXIT
+if [[ "${STORE_BBL_STATE_AS_TARBALL}" == "true" ]]; then
+  trap "rm -f ${PWD}/bbl-state/bbl-state.tgz ${PWD}/bbl-state/bbl-state.tgz.uncompressed; tar czf '${PWD}/updated-bbl-state/bbl-state.tgz' -C '${PWD}/bbl-state' ." EXIT
+else
+  trap "commit_bbl_state_dir ${PWD} 'Remove bbl state dir'" EXIT
+fi
 
 main ${PWD}

--- a/bbl-destroy/task.yml
+++ b/bbl-destroy/task.yml
@@ -42,9 +42,15 @@ params:
   BBL_AZURE_CLIENT_SECRET:
   BBL_AZURE_TENANT_ID:
   BBL_AZURE_SUBSCRIPTION_ID:
-                
+
   # GCP Configuration Params
   # - Required for GCP
   BBL_GCP_SERVICE_ACCOUNT_KEY:
   # - Key content or path to the file containing credentials downloaded from GCP
   # - Path is relative to the `bbl-state` input
+
+  STORE_BBL_STATE_AS_TARBALL: false
+  # - Optional
+  # - Creates a tarball of the bbl-state directory, instead of treating it
+  # - as a git repo and committing.
+  # - This is useful if you want to store your state file in S3 or GCS.

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -109,6 +109,10 @@ function main() {
   popd
 }
 
-trap "commit_bbl_state_dir ${PWD} '${GIT_COMMIT_MESSAGE}'" EXIT
+if [[ "${STORE_BBL_STATE_AS_TARBALL}" == "true" ]]; then
+  trap "rm -f ${PWD}/bbl-state/bbl-state.tgz ${PWD}/bbl-state/bbl-state.tgz.uncompressed; tar czf '${PWD}/updated-bbl-state/bbl-state.tgz' -C '${PWD}/bbl-state' ." EXIT
+else
+  trap "commit_bbl_state_dir ${PWD} 'Remove bbl state dir'" EXIT
+fi
 
 main ${PWD}

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -111,3 +111,9 @@ params:
   # - BE CAREFUL! For public pipelines it can cause credentials disclosure.
   # - With `false` all output from BBL calls will be saved in log files inside concourse job only.
   # - Set this to `true` to see all output straight in the pipeline.
+
+  STORE_BBL_STATE_AS_TARBALL: false
+  # - Optional
+  # - Creates a tarball of the bbl-state directory, instead of treating it
+  # - as a git repo and committing.
+  # - This is useful if you want to store your state file in S3 or GCS.


### PR DESCRIPTION
### What is this change about?

This PR updates the `bbl-up` and `bbl-destroy` tasks to create tarballs from the bbl-state directory instead of attempting to commit them to a git repository. This allows the tarball to be uploaded to S3 or GCS by a subsequent `put` step. This is controlled by an optional `STORE_BBL_STATE_AS_TARBALL` parameter.

### Please provide contextual information.

This change is somewhat, but not entirely, related to the request made in this issue: https://github.com/cloudfoundry/cf-deployment-concourse-tasks/issues/88

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in release notes?

The `bbl-up` and `bbl-destroy` tasks can now create tarballs from the bbl-state directory instead of attempting to commit them to a git repository. This allows the tarball to be uploaded to S3 or GCS by a subsequent `put` step. This is controlled by an optional `STORE_BBL_STATE_AS_TARBALL` parameter.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
