### PR TITLE
Resolve force_flag: unbound variable error

### DIFF
--- a/bosh-delete-deployment/task
+++ b/bosh-delete-deployment/task
@@ -8,6 +8,12 @@ function bosh_delete_all_deployments() {
     local deployments
     deployments=$(bosh deployments --json | jq -r '.Tables[].Rows[].name')
 
+    local force_flag=""
+
+    if [ "$IGNORE_ERRORS" = true ]; then
+        force_flag="--force"
+    fi
+
     for deployment in ${deployments}; do
       if [ -n "${deployment}" ]; then
         echo "Deleting deployment: ${deployment}"


### PR DESCRIPTION
When deleting all bosh deployments, we reference the force_flag but it is not set in that function.

### What is this change about?

_Describe the change and why it's needed._


### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._



### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [ ] N/A



### How should this change be described in release notes?

_Something brief that conveys the change and is written with the component author audience in mind._



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
