### PR TITLE
shared-functions: Add BOSH_DEPLOY_ARGS to uptimer_config

### DIFF
--- a/shared-functions
+++ b/shared-functions
@@ -173,10 +173,11 @@ write_uptimer_deploy_config() {
     --arg streaming_logs ${STREAMING_LOGS_THRESHOLD} \
     --arg use_single_app_instance ${USE_SINGLE_APP_INSTANCE} \
     --arg app_syslog_availability ${APP_SYSLOG_AVAILABILITY_THRESHOLD} \
+    --arg bosh_deploy_args ${BOSH_DEPLOY_ARGS} \
     '{
       "while": [{
         "command":"bosh",
-        "command_args":["--tty", "-n", "deploy", $manifest, "-d", $deployment_name]
+        "command_args":["--tty", "-n", "deploy", $bosh_deploy_args, $manifest, "-d", $deployment_name]
       }],
       "cf": {
         "api": $cf_api,


### PR DESCRIPTION
### What is this change about?

_Describe the change and why it's needed._
This change makes the bosh_deploy function consistent when the DEPLOY_WITH_UPTIME_MEASUREMENTS  is used. Previously if you passed BOSH_DEPLOY_ARGS in your task configuration without using DEPLOY_WITH_UPTIME_MEASUREMENTS, `bosh deploy` would respect your BOSH_DEPLOY_ARGS. If DEPLOY_WITH_UPTIME_MEASUREMENTS is set to true, then BOSH_DEPLOY_ARGS would be silently ignored. 

### Please provide contextual information.

N/A, we found this issue in our internal concourse pipeline and thought that would be nice to make things consistent.

### Please check all that apply for this PR:
- [ ] introduces a new task
- [X] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A


### How should this change be described in release notes?

Consistently pass BOSH_DEPLOY_ARGS to bosh_deploy() shared function.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
