### PR TITLE
Delete Terraform plugins before pushing bbl state

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -110,6 +110,10 @@ function main() {
     eval bbl --debug up \
       ${name_flag} \
       ${lb_flags} "2>&1" ${drain} "${root_dir}/bbl_up.log"
+
+    if [[ "${DELETE_TERRAFORM_PLUGINS}" == "true" ]]; then
+      rm -rf "terraform/.terraform"
+    fi
   popd
 }
 

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -120,6 +120,13 @@ params:
   # - as a git repo and committing.
   # - This is useful if you want to store your state file in S3 or GCS.
 
+  DELETE_TERRAFORM_PLUGINS: true
+  # - Optional
+  # - Deletes Terraform plugins in the bbl state directory before pushing or uploading state
+  # - These plugins are very large (around 50 MB for the Google plugin, for instance)
+  # - bbl will replace them on its next operation
+  # - Set this to `false` to keep these plugins
+
   BBL_JSON_CONFIG:
   # - Optional
   # - For if you need a dynamic config for BBL


### PR DESCRIPTION
### What is this change about?

This change deletes Terraform plugins from the bbl state directory in the bbl-up task before pushing the state to GitHub or tarring and uploading it to S3/GCS/etc.

These plugin files are very large (the GCP one is around 50 MB), and bbl will re-download them as needed using `terraform init` before every operation, so it's not necessary to keep them on disk.

There was some discussion between us over whether this new behavior should be default or not. We introduced a new parameter, `DELETE_TERRAFORM_PLUGINS`, to the bbl-up task to control this new behavior. This is currently defaulting to true but we are open to changing it to default false as well.


### Please provide contextual information.

This PR came out of an in-person discussion with @vitreuz and @acosta11.

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

(my pair thinks this is a breaking change but I don't)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

_Delete Terraform plugins from the bbl-state repo before pushing it to Git or uploading it. This new behavior can be disabled._



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
cc @bruce-ricard
cc @cloudfoundry/pcf-toolsmiths 
