### PR TITLE
Make vars-files input optional on bosh-deploy task

### DIFF
--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -12,6 +12,7 @@ inputs:
 - name: cf-deployment  # - The cf-deployment manifest
 - name: ops-files  # - Operations files to be made available
 - name: vars-files  # - Variable files to be made available
+  optional: true
 - name: cf-deployment-concourse-tasks  # - This repo
 - name: pool-lock
   optional: true


### PR DESCRIPTION
### What is this change about?

Looks like the task script is happy for this directory to be empty, yet the task will fail if it is not provided as an input. This is not so convenient for users who do not have any vars files to provide. Thus, make it an optional input.


### Please provide contextual information.

https://cloudfoundry.slack.com/archives/C0FAEKGUQ/p1572475327009500


### Please check all that apply for this PR:
- [ ] introduces a new task
- [X] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A



### How should this change be described in release notes?

vars-files input is now optional on bosh-deploy task

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@tylerschultz