### PR TITLE
Can use toolsmiths-env metadata

### DIFF
--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -9,6 +9,9 @@ image_resource:
 
 inputs:
 - name: bbl-state  # - The repo containing the Director's bbl state dir
+  optional: true
+- name: toolsmiths-env  # - Directory containing Toolsmiths metadata file
+  optional: true
 - name: cf-deployment  # - The cf-deployment manifest
 - name: ops-files  # - Operations files to be made available
 - name: vars-files  # - Variable files to be made available

--- a/bosh-deploy-with-updated-release-submodule/task.yml
+++ b/bosh-deploy-with-updated-release-submodule/task.yml
@@ -9,6 +9,9 @@ image_resource:
 
 inputs:
 - name: bbl-state  # - The repo containing the Director's bbl state dir
+  optional: true
+- name: toolsmiths-env  # - Directory containing Toolsmiths metadata file
+  optional: true
 - name: cf-deployment  # - The cf-deployment manifest
 - name: ops-files  # - Operations files to be made available
 - name: vars-files  # - Variable files to be made available

--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -9,6 +9,9 @@ image_resource:
 
 inputs:
 - name: bbl-state  # - The repo containing the Director's bbl state dir
+  optional: true
+- name: toolsmiths-env  # - Directory containing Toolsmiths metadata file
+  optional: true
 - name: cf-deployment  # - The cf-deployment manifest
 - name: ops-files  # - Operations files to be made available
   optional: true

--- a/bosh-upload-stemcells/task.yml
+++ b/bosh-upload-stemcells/task.yml
@@ -11,6 +11,9 @@ inputs:
 - name: cf-deployment-concourse-tasks  # - This repo
 - name: cf-deployment  # - The cf-deployment manifest
 - name: bbl-state  # - The repo containing the Director's bbl state dir
+  optional: true
+- name: toolsmiths-env  # - Directory containing Toolsmiths metadata file
+  optional: true
 - name: ops-files  # - Oplitonal operations files to be made available
   optional: true
 

--- a/open-asgs-for-bosh-instance-group/task.yml
+++ b/open-asgs-for-bosh-instance-group/task.yml
@@ -9,6 +9,9 @@ image_resource:
 
 inputs:
 - name: bbl-state
+  optional: true
+- name: toolsmiths-env  # - Directory containing Toolsmiths metadata file
+  optional: true
 - name: cf-deployment-concourse-tasks
 
 run:

--- a/run-errand/task.yml
+++ b/run-errand/task.yml
@@ -9,6 +9,9 @@ image_resource:
 
 inputs:
 - name: bbl-state
+  optional: true
+- name: toolsmiths-env  # - Directory containing Toolsmiths metadata file
+  optional: true
 - name: cf-deployment-concourse-tasks
 - name: pool-lock
   optional: true

--- a/set-feature-flags/task.yml
+++ b/set-feature-flags/task.yml
@@ -10,6 +10,9 @@ image_resource:
 inputs:
 - name: cf-deployment-concourse-tasks # - This repo
 - name: bbl-state  # - The repo containing the Director's bbl state dir
+  optional: true
+- name: toolsmiths-env  # - Directory containing Toolsmiths metadata file
+  optional: true
 
 run:
   path: cf-deployment-concourse-tasks/set-feature-flags/task

--- a/shared-functions
+++ b/shared-functions
@@ -81,7 +81,7 @@ function set_git_config() {
 function setup_bosh_env_vars() {
   set +x
   if [ -d toolsmiths-env ]; then
-    eval "$(bbl print-env --file toolsmiths-env/metadata)"
+    eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
   else
     if [ -d bbl-state ]; then
       pushd "bbl-state/${BBL_STATE_DIR}"

--- a/shared-functions
+++ b/shared-functions
@@ -80,9 +80,18 @@ function set_git_config() {
 
 function setup_bosh_env_vars() {
   set +x
-  pushd "bbl-state/${BBL_STATE_DIR}"
-    eval "$(bbl print-env)"
-  popd
+  if [ -d toolsmiths-env ]; then
+    eval "$(bbl print-env --file toolsmiths-env/metadata)"
+  else
+    if [ -d bbl-state ]; then
+      pushd "bbl-state/${BBL_STATE_DIR}"
+        eval "$(bbl print-env)"
+      popd
+    else
+      echo "Must provide either toolsmiths-env or bbl-state as an input"
+      exit 1
+    fi
+  fi
   set -x
 }
 

--- a/update-integration-configs/task.yml
+++ b/update-integration-configs/task.yml
@@ -9,6 +9,9 @@ image_resource:
 
 inputs:
 - name: bbl-state  # - The repo containing the Director's bbl state dir
+  optional: true
+- name: toolsmiths-env  # - Directory containing Toolsmiths metadata file
+  optional: true
 - name: cf-deployment-concourse-tasks # - This repo
 - name: integration-configs # - Integration configs to be updated
 


### PR DESCRIPTION
### What is this change about?

This PR adds a new `toolsmiths-env` input to many of the tasks relying on bbl state (specifically, to tasks which do not run bbl commands other than `print-env` and which are not involved with cleaning up an environment. The `bbl-state` input is now optional, although the tasks will error if neither input is provided. When the `toolsmiths-env` input is provided, the new `--file` flag will be provided to `bbl print-env`, which will read desired environment variables from the Toolsmiths environments app metadata file.

This is necessary for users of Toolsmiths cf-deployment environments to be able to use cf-deployment-concourse-tasks, since the Toolsmiths environments app does not provide users with a full bbl state.

### Please provide contextual information.

This depends on [this PR](https://github.com/cloudfoundry/bosh-bootloader/pull/490) being merged.

Related Tracker stories:
- [Modify bbl print-env to take metadata as input instead of bbl.state](https://www.pivotaltracker.com/story/show/169765098)
- [Update concourse tasks repo to use our new bbl flag](https://www.pivotaltracker.com/story/show/169765263)

[Related Slack thread](https://pivotal.slack.com/archives/C3LUD2L04/p1574194486018600) (unfortunately most of the actual discussion of this was done over video and unrecorded)


### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Allow users to specify Toolsmiths' metadata instead of bbl state when targeting environments.


### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
cc @nhsieh @cloudfoundry/pcf-toolsmiths
