### PR TITLE
Fixes metadata capability for toolsmiths-env

### DIFF
--- a/shared-functions
+++ b/shared-functions
@@ -400,20 +400,21 @@ upload_stemcell() {
   else
     infrastructure="$(jq -r .iaas bbl-state/${BBL_STATE_DIR}/bbl-state.json)"
 
-  if [ "${BOSH_LITE}" == "true"  ]; then
-    infrastructure="bosh-lite"
-  fi
+    if [ "${BOSH_LITE}" == "true"  ]; then
+      infrastructure="bosh-lite"
+    fi
 
-  if [ "$infrastructure" = "bosh-lite" ]; then
-    stemcell_name="bosh-warden-boshlite"
-  elif [ "$infrastructure" = "aws" ]; then
-    stemcell_name="bosh-aws-xen-hvm"
-  elif [ "$infrastructure" = "gcp" ]; then
-    stemcell_name="bosh-google-kvm"
-  elif [ "$infrastructure" = "vsphere" ]; then
-    stemcell_name="bosh-vsphere-esxi"
-  elif [ "$infrastructure" = "azure" ]; then
-    stemcell_name="bosh-azure-hyperv"
+    if [ "$infrastructure" = "bosh-lite" ]; then
+      stemcell_name="bosh-warden-boshlite"
+    elif [ "$infrastructure" = "aws" ]; then
+      stemcell_name="bosh-aws-xen-hvm"
+    elif [ "$infrastructure" = "gcp" ]; then
+      stemcell_name="bosh-google-kvm"
+    elif [ "$infrastructure" = "vsphere" ]; then
+      stemcell_name="bosh-vsphere-esxi"
+    elif [ "$infrastructure" = "azure" ]; then
+      stemcell_name="bosh-azure-hyperv"
+    fi
   fi
 
   stemcell_name="${stemcell_name}-${os}-go_agent"

--- a/shared-functions
+++ b/shared-functions
@@ -395,7 +395,8 @@ upload_stemcell() {
 
   local infrastructure
   if [ -d toolsmiths-env ]; then
-    infrastructure="bosh-google-kvm"
+    infrastructure="gcp"
+    stemcell_name="bosh-google-kvm"
   else
     infrastructure="$(jq -r .iaas bbl-state/${BBL_STATE_DIR}/bbl-state.json)"
 

--- a/shared-functions
+++ b/shared-functions
@@ -81,7 +81,7 @@ function set_git_config() {
 function setup_bosh_env_vars() {
   set +x
   if [ -d toolsmiths-env ]; then
-    eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
+    eval "$(bbl print-env --metadata-file toolsmiths-env/metadata.json)"
   else
     if [ -d bbl-state ]; then
       pushd "bbl-state/${BBL_STATE_DIR}"
@@ -297,13 +297,18 @@ function remove_credentials_from_credhub_in_directory() {
 }
 
 function remove_credentials_from_credhub() {
-  local director_name
-  director_name=$(jq -r .bosh.directorName bbl-state/${BBL_STATE_DIR}/bbl-state.json)
-
+  local directory_name
   local deployment_name
-  deployment_name=$(bosh interpolate "${INTERPOLATED_MANIFEST}" --path /name)
-
-  remove_credentials_from_credhub_in_directory "/${director_name}/${deployment_name}"
+  if [ -d toolsmiths-env ]; then
+    deployment_name=$(jq -r .name toolsmiths-env/metadata.json)
+    directory_name="/bosh-${deployment_name}"
+  else
+    local director_name
+    director_name=$(jq -r .bosh.directorName bbl-state/${BBL_STATE_DIR}/bbl-state.json)
+    deployment_name=$(bosh interpolate "${INTERPOLATED_MANIFEST}" --path /name)
+    directory_name="/${director_name}/${deployment_name}"
+  fi
+  remove_credentials_from_credhub_in_directory ${directory_name}
 }
 
 write_gcp_service_account_key() {
@@ -389,7 +394,10 @@ upload_stemcell() {
   local stemcell_name
 
   local infrastructure
-  infrastructure="$(jq -r .iaas bbl-state/${BBL_STATE_DIR}/bbl-state.json)"
+  if [ -d toolsmiths-env ]; then
+    infrastructure="bosh-google-kvm"
+  else
+    infrastructure="$(jq -r .iaas bbl-state/${BBL_STATE_DIR}/bbl-state.json)"
 
   if [ "${BOSH_LITE}" == "true"  ]; then
     infrastructure="bosh-lite"


### PR DESCRIPTION
### What is this change about?
Fixes the metadata code for toolsmiths-env added in a previous PR.



### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._
The issue is that some functions were still looking at the bbl-state and not toolsmiths-env, so this PR adds code to resolve this issue raised by: 
[this Slack interrupt](https://pivotal.slack.com/archives/C0563B53F/p1574727529363200)
[which opened this story](https://www.pivotaltracker.com/story/show/169967286)

To fix: [this PR](https://github.com/cloudfoundry/cf-deployment-concourse-tasks/commit/1f69f207f00fa48d267f51d45d3c9b38eca3a771)


### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Fixes bug in allowing users to specify Toolsmiths' metadata instead of bbl state when targeting environments.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
cc @nhsieh @bbtong @cloudfoundry/pcf-toolsmiths
