### PR TITLE
Fix toolsmiths metadata path

### DIFF
--- a/shared-functions
+++ b/shared-functions
@@ -81,7 +81,7 @@ function set_git_config() {
 function setup_bosh_env_vars() {
   set +x
   if [ -d toolsmiths-env ]; then
-    eval "$(bbl print-env --metadata-file toolsmiths-env/metadata.json)"
+    eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
   else
     if [ -d bbl-state ]; then
       pushd "bbl-state/${BBL_STATE_DIR}"
@@ -300,7 +300,7 @@ function remove_credentials_from_credhub() {
   local directory_name
   local deployment_name
   if [ -d toolsmiths-env ]; then
-    deployment_name=$(jq -r .name toolsmiths-env/metadata.json)
+    deployment_name=$(jq -r .name toolsmiths-env/metadata)
     directory_name="/bosh-${deployment_name}"
   else
     local director_name


### PR DESCRIPTION
Signed-off-by: Rowan Jacobs <rojacobs@pivotal.io>

### What is this change about?

Fixes the path to Toolsmiths environment metadata.


### Please provide contextual information.

Related to PR #102 

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Fixes the path to Toolsmiths environment metadata.



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

cc @bbtong
