### PR TITLE
feature: set SYSTEM_DOMAIN variable for toolsmiths

### DIFF
--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -42,7 +42,7 @@ params:
   # - The path is relative to root of the `cf-deployment` input
 
   SYSTEM_DOMAIN:
-  # - Required
+  # - Required unless toolsmiths-env optional input is provided
   # - CF system base domain e.g. `my-cf.com`
 
   OPS_FILES:

--- a/bosh-deploy-with-updated-release-submodule/task.yml
+++ b/bosh-deploy-with-updated-release-submodule/task.yml
@@ -37,7 +37,7 @@ params:
   # - The path is relative to root of the `cf-deployment` input
 
   SYSTEM_DOMAIN:
-  # - Required
+  # - Required unless toolsmiths-env optional input is provided
   # - CF system base domain e.g. `my-cf.com`
 
   OPS_FILES:

--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -37,7 +37,7 @@ params:
   # - The path is relative to root of the `cf-deployment` input
 
   SYSTEM_DOMAIN:
-  # - Required
+  # - Required unless toolsmiths-env optional input is provided
   # - CF system base domain e.g. `my-cf.com`
 
   OPS_FILES:

--- a/open-asgs-for-bosh-instance-group/task.yml
+++ b/open-asgs-for-bosh-instance-group/task.yml
@@ -35,7 +35,7 @@ params:
   # - communication to
 
   SYSTEM_DOMAIN:
-  # - Required
+  # - Required unless toolsmiths-env optional input is provided
   # - CF system base domain e.g. `my-cf.com`
 
   SECURITY_GROUP_NAME:

--- a/set-feature-flags/task.yml
+++ b/set-feature-flags/task.yml
@@ -19,7 +19,7 @@ run:
 
 params:
   SYSTEM_DOMAIN:
-  # - Required
+  # - Required unless toolsmiths-env optional input is provided
   # - CF system base domain e.g. `my-cf.com`
 
   BBL_STATE_DIR: bbl-state

--- a/shared-functions
+++ b/shared-functions
@@ -19,8 +19,8 @@ function check_input_params() {
     exit 1
   fi
 
-  if [ -z "$SYSTEM_DOMAIN" ]; then
-    echo "SYSTEM_DOMAIN has not been set"
+  if [ -z "$SYSTEM_DOMAIN" -a ! -d toolsmiths-env ]; then
+    echo "SYSTEM_DOMAIN or toolsmiths-env needs to be passed in"
     exit 1
   fi
 
@@ -82,6 +82,7 @@ function setup_bosh_env_vars() {
   set +x
   if [ -d toolsmiths-env ]; then
     eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
+    export SYSTEM_DOMAIN="$(cat toolsmiths-env/name).cf-app.com"
   else
     if [ -d bbl-state ]; then
       pushd "bbl-state/${BBL_STATE_DIR}"


### PR DESCRIPTION
Co-authored-by: Bruce Ricard <bricard@pivotal.io>

### What is this change about?

When using a toolsmiths environment, the SYSTEM_DOMAIN is dynamically
fetched from the metadata. It cannot be passed as a parameter in the
pipeline configuration.


### Please provide contextual information.

https://www.pivotaltracker.com/story/show/169068487

### Please check all that apply for this PR:
- [ ] introduces a new task
- [X] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

The error message is slightly different now. Not sure if that counts as a breaking change.

### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A

### How should this change be described in release notes?

Tasks can be used with toolsmiths Cf-Deployment environments

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

We are technically blocked, but are using our fork in the meantime.

### Tag your pair, your PM, and/or team!
@bruce-ricard 
#networking in slack
