### PR TITLE
Fix issue with set-feature-flags task

### DIFF
--- a/set-feature-flags/task
+++ b/set-feature-flags/task
@@ -3,11 +3,6 @@
 # shellcheck disable=SC1091
 source cf-deployment-concourse-tasks/shared-functions
 
-if [ -z "${SYSTEM_DOMAIN}" ]; then
-  echo '$SYSTEM_DOMAIN is a required parameter'
-  exit 1
-fi
-
 function set_enabled_feature_flags() {
   if [ ! -z "${ENABLED_FEATURE_FLAGS}" ]; then
     for flag in $ENABLED_FEATURE_FLAGS; do
@@ -40,9 +35,14 @@ function cf_login() {
 }
 
 function main() {
-  cf api --skip-ssl-validation "api.${SYSTEM_DOMAIN}"
-
   setup_bosh_env_vars
+
+  if [ -z "${SYSTEM_DOMAIN}" ]; then
+    echo "SYSTEM_DOMAIN is a required parameter"
+    exit 1
+  fi
+
+  cf api --skip-ssl-validation "api.${SYSTEM_DOMAIN}"
   cf_login
 
   set_enabled_feature_flags


### PR DESCRIPTION
### What is this change about?

The current SYSTEM_DOMAIN check runs before it can be set by `setup_bosh_env_vars`, which causes it to fail if the value is being read from an environment metadata file.

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in release notes?

Fix a bug in the set-feature-flag task introduced in the last release where it would fail if used with a toolsmiths environment.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
