### PR TITLE
Add private docker registry support to update-intergration-configs task

### DIFF
--- a/update-integration-configs/task
+++ b/update-integration-configs/task
@@ -61,12 +61,15 @@ function main() {
       new_cats_integration_config=$(echo "${new_cats_integration_config}" | jq ".api=\"api.${SYSTEM_DOMAIN}\" | .apps_domain=\"${SYSTEM_DOMAIN}\"")
     fi
 
-    if [ -n "${PRIVATE_DOCKER_REGISTRY_IMAGE}" ]; then
+    if [[ -n "${PRIVATE_DOCKER_REGISTRY_IMAGE}" && -n "${PRIVATE_DOCKER_REGISTRY_USERNAME}" && -n "${PRIVATE_DOCKER_REGISTRY_PASSWORD}" ]]; then
       new_cats_integration_config=$( \
         echo "${new_cats_integration_config}" | \
         jq ".private_docker_registry_image=\"${PRIVATE_DOCKER_REGISTRY_IMAGE}\"" | \
         jq ".private_docker_registry_username=\"${PRIVATE_DOCKER_REGISTRY_USERNAME}\"" | \
         jq ".private_docker_registry_password=\"${PRIVATE_DOCKER_REGISTRY_PASSWORD}\"")
+    elif [[ -n "${PRIVATE_DOCKER_REGISTRY_IMAGE}" || -n "${PRIVATE_DOCKER_REGISTRY_USERNAME}" || -n "${PRIVATE_DOCKER_REGISTRY_PASSWORD}" ]]; then
+      echo "All 3 private docker registry keys must be provided. (PRIVATE_DOCKER_REGISTRY_IMAGE, PRIVATE_DOCKER_REGISTRY_USERNAME, and PRIVATE_DOCKER_REGISTRY_PASSWORD)"
+      exit 1
     fi
 
     echo "${new_cats_integration_config}" > "integration-configs/${CATS_INTEGRATION_CONFIG_FILE}"

--- a/update-integration-configs/task
+++ b/update-integration-configs/task
@@ -61,6 +61,14 @@ function main() {
       new_cats_integration_config=$(echo "${new_cats_integration_config}" | jq ".api=\"api.${SYSTEM_DOMAIN}\" | .apps_domain=\"${SYSTEM_DOMAIN}\"")
     fi
 
+    if [ -n "${PRIVATE_DOCKER_REGISTRY_IMAGE}" ]; then
+      new_cats_integration_config=$( \
+        echo "${new_cats_integration_config}" | \
+        jq ".private_docker_registry_image=\"${PRIVATE_DOCKER_REGISTRY_IMAGE}\"" | \
+        jq ".private_docker_registry_username=\"${PRIVATE_DOCKER_REGISTRY_USERNAME}\"" | \
+        jq ".private_docker_registry_password=\"${PRIVATE_DOCKER_REGISTRY_PASSWORD}\"")
+    fi
+
     echo "${new_cats_integration_config}" > "integration-configs/${CATS_INTEGRATION_CONFIG_FILE}"
   fi
 

--- a/update-integration-configs/task.yml
+++ b/update-integration-configs/task.yml
@@ -49,3 +49,11 @@ params:
   GIT_COMMIT_USERNAME: "CI Bot"
   # - Optional
   # - You may choose the git committer username and email address by setting these
+
+  PRIVATE_DOCKER_REGISTRY_IMAGE:
+  PRIVATE_DOCKER_REGISTRY_USERNAME:
+  PRIVATE_DOCKER_REGISTRY_PASSWORD:
+  # - Optional
+  # - You may add private docker registry information to the integration-configs
+  # - Specifying PRIVATE_DOCKER_REGISTRY_IMAGE will automatically assume that the
+  # PRIVATE_DOCKER_REGISTRY_USERNAME and PRIVATE_DOCKER_REGISTRY_PASSWORD is defined

--- a/update-integration-configs/task.yml
+++ b/update-integration-configs/task.yml
@@ -55,5 +55,4 @@ params:
   PRIVATE_DOCKER_REGISTRY_PASSWORD:
   # - Optional
   # - You may add private docker registry information to the integration-configs
-  # - Specifying PRIVATE_DOCKER_REGISTRY_IMAGE will automatically assume that the
-  # PRIVATE_DOCKER_REGISTRY_USERNAME and PRIVATE_DOCKER_REGISTRY_PASSWORD is defined
+  # - In order to apply private docker registry config, you must provide PRIVATE_DOCKER_REGISTRY_IMAGE & PRIVATE_DOCKER_REGISTRY_USERNAME & PRIVATE_DOCKER_REGISTRY_PASSWORD


### PR DESCRIPTION
### What is this change about?

CATS has the option to test private docker registries, this PR adds that support to update-integration-configs task so that the credentials doesn't have to get committed to repositories if it's public. 

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in release notes?

Add support for populating integration-configs with private docker registries

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**