### PR TITLE
Fix release_name bosh-deploy-with-created-release

### DIFF
--- a/bosh-deploy-with-created-release/task
+++ b/bosh-deploy-with-created-release/task
@@ -34,11 +34,11 @@ main() {
 
   local release_name
   release_name="$(yq '.name' release/config/final.yml)"
-  if [[ -z "${release_name}" ]]; then
+  if [[ "${release_name}" == "null" ]]; then
     release_name="$(yq '.final_name' release/config/final.yml)"
   fi
-  if [[ -z "${release_name}" ]]; then
-    echo "Expected non-empty 'name' in release/config/final.yml"
+  if [[ "${release_name}" == "null" ]]; then
+    echo "Expected non-empty 'name' or 'final_name' in release/config/final.yml"
     exit 1
   fi
 


### PR DESCRIPTION
- `yq` returns `null` not empty when `name` or `final_name` is not found

Signed-off-by: David McClure <dmcclure@vmware.com>

### What is this change about?

Our builds began failing with this error after updating to a recent version of this repo:
```
+ bosh -n interpolate -v system_domain=ci-lite.routing.cf-app.com -o ops-files/use-compiled-releases.yml -o ops-files/bosh-lite.yml -o ops-files/use-postgres.yml -o ops-files/routing-acceptance-tests.yml -o ops-files/routing-smoke-tests.yml -o ops-files/add-lb-ca-cert.yml -o create-provided-release.yml cf-deployment/cf-deployment.yml
Error 'operation [0] in create-provided-release.yml failed': Expected to find exactly one matching array item for path '/releases/name=null' but found 0
```


### Please provide contextual information.

Fixes regression introduced in this commit: https://github.com/cloudfoundry/cf-deployment-concourse-tasks/commit/9e45d4c837a77b956e4e97e99ea44ad0ccd3b322



### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Fix regression in `bosh-deploy-with-created-release`



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

cc @ameowlia
