### PR TITLE
ENH: fast fail in pipe chains

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -1,4 +1,4 @@
-#!/bin/bash -xeu
+#!/bin/bash -xeuo pipefail
 
 # shellcheck disable=SC1091
 source cf-deployment-concourse-tasks/shared-functions


### PR DESCRIPTION
Co-authored-by: Peter Chen <peterch@vmware.com>

### What is this change about?

Making the world a better place

### Please provide contextual information.

A recent commit introduced a pipe chain with a yq in it and our job failed with "yq: command not found" but kept running since it was followed by a pipe.


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
- [x] **Slightly Less urgent than Slightly less than Urgent**



### Tag your pair, your PM, and/or team!
@peterhaochen47