### PR TITLE
Move pipefail option in bbl-up/task script

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -1,4 +1,6 @@
-#!/bin/bash -xeuo pipefail
+#!/bin/bash -xeu
+
+set -o pipefail
 
 # shellcheck disable=SC1091
 source cf-deployment-concourse-tasks/shared-functions


### PR DESCRIPTION
### What is this change about?

A previous PR introduced the `pipefail` option to the `bbl-up` task. However, the formatting of that change does not work on linux machines, since linux interprets anything after the shebang as one argument (see https://unix.stackexchange.com/questions/533415/invalid-option-name-error-with-shebang-bin-bash-o-pipefail-in-script). 
This is a simple change to pull the `pipefail` option into a newline so it gets parsed correctly.

### Please provide contextual information.

Previous PR: https://github.com/cloudfoundry/cf-deployment-concourse-tasks/pull/116

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)


### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

*but worth calling out that this had broken our pipeline, and may have done the same for others.

### Tag your pair, your PM, and/or team!
@sweinstein22
