### PR TITLE
Replace docker-image with registry-image resource

### DIFF
--- a/bbl-destroy/task.yml
+++ b/bbl-destroy/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/bosh-cleanup/task.yml
+++ b/bosh-cleanup/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/bosh-delete-deployment/task.yml
+++ b/bosh-delete-deployment/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/bosh-deploy-with-updated-release-submodule/task.yml
+++ b/bosh-deploy-with-updated-release-submodule/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/bosh-upload-stemcells/task.yml
+++ b/bosh-upload-stemcells/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/collect-ops-files/task.yml
+++ b/collect-ops-files/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/open-asgs-for-bosh-instance-group/task.yml
+++ b/open-asgs-for-bosh-instance-group/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/run-cats/task.yml
+++ b/run-cats/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/run-errand/task.yml
+++ b/run-errand/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/set-feature-flags/task.yml
+++ b/set-feature-flags/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest

--- a/update-integration-configs/task.yml
+++ b/update-integration-configs/task.yml
@@ -2,7 +2,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/cf-deployment-concourse-tasks
     tag: latest


### PR DESCRIPTION
### What is this change about?

The registry-image resource was introduced more than two years ago as a drop-in replace for the docker-image resource. It's less resource-intense, faster, and doesn't rely on spawning a Docker daemon.

### Please provide contextual information.

- https://github.com/concourse/registry-image-resource

### Please check all that apply for this PR:
- [ ] introduces a new task
- [X] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A

### How should this change be described in release notes?

Replace docker-image with registry-image resource.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!

N/A.