### PR TITLE
 Make `ops-files` and `vars-files` inputs optional

### DIFF
--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -14,7 +14,9 @@ inputs:
   optional: true
 - name: cf-deployment  # - The cf-deployment manifest
 - name: ops-files  # - Operations files to be made available
+  optional: true
 - name: vars-files  # - Variable files to be made available
+  optional: true
 - name: release
 # - BOSH release source repo or directory containing a release tarball
 # - If the input is a git repository, a dev release will be created from

--- a/bosh-deploy-with-updated-release-submodule/task.yml
+++ b/bosh-deploy-with-updated-release-submodule/task.yml
@@ -14,7 +14,9 @@ inputs:
   optional: true
 - name: cf-deployment  # - The cf-deployment manifest
 - name: ops-files  # - Operations files to be made available
+  optional: true
 - name: vars-files  # - Variable files to be made available
+  optional: true
 - name: release
 # - BOSH release source repo
 # - A dev release will be created from this repo and used in the deployment


### PR DESCRIPTION
### What is this change about?
 Make `ops-files` and `vars-files` inputs optional
 * They are not used if the pipeline user is using default cf-deployment setup
 * This causes users to add dummy / unused resources and adds pipeline cruft

### Please provide contextual information.

https://vmware.slack.com/archives/C01ERQAVD2L/p1631131092013600


### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

_Something brief that conveys the change and is written with the component author audience in mind._



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@cloudfoundry/runtime 