### PR TITLE
Remove the Ginkgo CLI

### DIFF
--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -113,7 +113,7 @@ RUN \
 
 RUN \
   go install github.com/cloudfoundry/uptimer@${uptimer_version} && \
-  go install github.com/onsi/ginkgo/ginkgo@latest
+  go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
 # Add trusted relint ca certificate
 ARG RELINT_CA_CERTIFICATE

--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -111,9 +111,8 @@ RUN \
   wget https://github.com/cloudfoundry/log-cache-cli/releases/download/v${log_cache_cli_version}/log-cache-cf-plugin-linux -P /tmp && \
   cf install-plugin /tmp/log-cache-cf-plugin-linux -f
 
-RUN \
-  go install github.com/cloudfoundry/uptimer@${uptimer_version} && \
-  go install github.com/onsi/ginkgo/v2/ginkgo@latest
+# uptimer
+RUN go install github.com/cloudfoundry/uptimer@${uptimer_version}
 
 # Add trusted relint ca certificate
 ARG RELINT_CA_CERTIFICATE


### PR DESCRIPTION
### What is this change about?

~This PR bumps the version of the Ginkgo CLI included in the docker image to v2 to match the version used in CATs.~

Edit: This PR removes the ginkgo CLI from the docker image, as the version of the CLI must match the local Ginkgo library version in any given project. Therefore, we need to push the responsibility onto project owners to vendor and use the tool appropriately.

### Please provide contextual information.

* Related to https://github.com/cloudfoundry/cf-acceptance-tests/pull/543
* https://github.com/onsi/ginkgo/releases/tag/v2.3.1

### Please check all that apply for this PR:
- [ ] introduces a new task
- [ ] changes an existing task
- [x] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in release notes?

~This PR bumps the version of the Ginkgo CLI included in the docker image to v2 to match the version used in CATs.~
This PR removes the ginkgo CLI from the docker image.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@ctlong 