### PR TITLE
Fix Ginkgo v1 install command

### DIFF
--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -113,7 +113,7 @@ RUN \
 
 RUN \
   go install github.com/cloudfoundry/uptimer@${uptimer_version} && \
-  go install github.com/onsi/ginkgo/...
+  go install github.com/onsi/ginkgo/ginkgo@latest
 
 # Add trusted relint ca certificate
 ARG RELINT_CA_CERTIFICATE


### PR DESCRIPTION
### What is this change about?

The current Ginkgo install command doesn't work anymore. This PR conflicts with https://github.com/cloudfoundry/cf-deployment-concourse-tasks/pull/127 (install Ginkgo v2). The cf-performance tests have not yet been migrated to v2, however.

### Please provide contextual information.

The current install fails with:
```
# go install github.com/onsi/ginkgo/...
go: warning: "github.com/onsi/ginkgo/..." matched no packages
```

I would propose to replace this with:
```
# go install github.com/onsi/ginkgo/ginkgo@latest
go: downloading golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e
go: downloading github.com/nxadm/tail v1.4.8
go: downloading golang.org/x/sys v0.0.0-20210112080510-489259a85091
go: downloading gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: downloading github.com/fsnotify/fsnotify v1.4.9
# ginkgo version
Ginkgo Version 1.16.5
```

### Please check all that apply for this PR:
- [ ] introduces a new task
- [ ] changes an existing task
- [x] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Fix for regression: Ginkgo v1 CLI is available again.



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

