### PR TITLE
Update run-cats to use the new Ginkgo v2 CLI flags

### DIFF
--- a/run-cats/task
+++ b/run-cats/task
@@ -49,11 +49,12 @@ export CF_DIAL_TIMEOUT=11
 export CF_PLUGIN_HOME=$HOME
 
 ./bin/test \
-  -keepGoing \
-  -randomizeAllSpecs \
-  -skipPackage=helpers \
-  -slowSpecThreshold="${SLOW_SPEC_THRESHOLD}" \
-  -nodes="${NODES}" \
-  -skip="${SKIP_REGEXP}" \
-  -flakeAttempts=${FLAKE_ATTEMPTS} \
-  -noisySkippings=false
+  --keep-going \
+  --randomize-all \
+  --skip-package=helpers \
+  --slow-spec-shreshold="${SLOW_SPEC_THRESHOLD}" \
+  --nodes="${NODES}" \
+  --skip="${SKIP_REGEXP}" \
+  --flake-attempts=${FLAKE_ATTEMPTS} \
+  --timeout="${TIMEOUT}" \
+  --no-color

--- a/run-cats/task.yml
+++ b/run-cats/task.yml
@@ -22,9 +22,9 @@ run:
   path: cf-deployment-concourse-tasks/run-cats/task
 
 params:
-  SLOW_SPEC_THRESHOLD: 315
+  SLOW_SPEC_THRESHOLD: 315s
   # - Optional
-  # - The amount of time, in seconds, to wait before marking a test as slow.
+  # - The amount of time, as a Golang time.Duration, to wait before marking a test as slow.
 
   NODES: 12
   # - Optional
@@ -55,3 +55,7 @@ params:
   FLAKE_ATTEMPTS: 2
   # - Optional
   # - The number of times to retry a single failed test
+
+  TIMEOUT: 2h
+  # - Optional
+  # - Timeout for the entire test run, as a Golang time.Duration.


### PR DESCRIPTION
### What is this change about?

This PR updates the flags specified in the run-cats task to use the new versions of the Ginkgo v2 CLI and updates the slow spec threshold to be a Golang time duration instead of a number of seconds. A new `TIMEOUT` parameter has been introduced to allow CI jobs to change the default Ginkgo timeout, which is now applied to the entire test suite run, instead of each individual test suite. It defaults to 2 hours, instead of the Ginkgo default of 1 hour.

### Please provide contextual information.

Related to https://github.com/cloudfoundry/cf-acceptance-tests/pull/543

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in release notes?

The Ginkgo CLI flags specified in the run-cats task have been updated to use the new versions of v2. The slow spec threshold has been updated to be a Golang time duration instead of a number of seconds. A new `TIMEOUT` parameter has been introduced to allow CI jobs to change the default Ginkgo timeout, which is now applied to the entire test suite run, instead of each individual test suite. It defaults to 2 hours, instead of the Ginkgo default of 1 hour.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@ctlong 
