### PR TITLE
improve output for bbl up/destroy tasks

### DIFF
--- a/bbl-destroy/task
+++ b/bbl-destroy/task
@@ -35,4 +35,4 @@ else
   trap "commit_bbl_state_dir ${PWD} 'Remove bbl state dir'" EXIT
 fi
 
-main ${PWD}
+main "$PWD"

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -113,8 +113,14 @@ function main() {
       ${name_flag} \
       ${lb_flags} "2>&1" ${drain} "${root_dir}/bbl_up.log"
 
-    echo "Please configure DNS with the following servers:"
-    bbl outputs | yq '.system_domain_dns_servers' -y | cut -d' ' -f2
+    ns_record_advisory="For DNS delegation to work, please ensure an NS record for ${LB_DOMAIN} is created in its parent DNS zone with the following nameservers:"
+    if [[ "$BBL_IAAS" == "aws" ]]; then
+      echo "$ns_record_advisory"
+      bbl outputs | yq '.env_dns_zone_name_servers[0:4]' --yaml-output | cut -d' ' -f2
+    elif [[ "$BBL_IAAS" == "gcp" ]]; then
+      echo "$ns_record_advisory"
+      bbl outputs | yq '.system_domain_dns_servers' --yaml-output | cut -d' ' -f2
+    fi
 
     if [[ "${DELETE_TERRAFORM_PLUGINS}" == "true" ]]; then
       rm -rf "terraform/.terraform"
@@ -128,4 +134,4 @@ else
   trap "commit_bbl_state_dir ${PWD} '${GIT_COMMIT_MESSAGE}'" EXIT
 fi
 
-main ${PWD}
+main "$PWD"


### PR DESCRIPTION
### What is this change about?

Fixes a small issue in the `bbl-up` task which causes it to fail to print the nameservers for the created DNS zone when deploying on AWS.

### Please provide contextual information.

For some odd reason, `bbl` gives this output different names for aws and gcp. For the latter it's named [system_domain_dns_servers](https://github.com/cloudfoundry/bosh-bootloader/blob/b9b92c7b41fca198b59d19e1848292838f7d9e9d/commands/gcp_lbs.go#L56), and for the former it's [env_dns_zone_name_servers](https://github.com/cloudfoundry/bosh-bootloader/blob/b9b92c7b41fca198b59d19e1848292838f7d9e9d/commands/aws_lbs.go#L60). As a result, this is the build output you currently get if you're running on aws (and presumably any other IaaS other than gcp):

```
Please configure DNS with the following servers:
+ bbl outputs
+ yq .system_domain_dns_servers -y
+ cut '-d ' -f2
null
```


### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Bug fix


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
