### PR TITLE
Fix use case of `bosh-deploy-with-created-release` task

### DIFF
--- a/bosh-deploy-with-created-release/task
+++ b/bosh-deploy-with-created-release/task
@@ -33,12 +33,18 @@ main() {
   setup_bosh_env_vars
 
   local release_name
+  local release_version
   if [[ -n ${RELEASE_NAME_OF_TARBALL} ]]; then
     if [[ ! -r "${root_dir}/release_tarball_name/name" ]]; then
       echo "When providing 'RELEASE_NAME_OF_TARBALL', 'release_tarball_name' must be given."
       exit 1
     fi
-    release_name=${RELEASE_NAME_OF_TARBALL}
+    if [[ -z ${RELEASE_VERSION_OF_TARBALL} ]]; then
+      echo "When providing 'RELEASE_NAME_OF_TARBALL', 'RELEASE_VERSION_OF_TARBALL' must be also given."
+      exit 1
+    fi
+    release_name="${RELEASE_NAME_OF_TARBALL}"
+    release_version="${RELEASE_VERSION_OF_TARBALL}"
   else
     release_name="$(yq -r '.name' release/config/final.yml)"
     if [[ "${release_name}" == "null" ]]; then
@@ -51,7 +57,7 @@ main() {
   fi
 
   if [[ -r "${root_dir}/release_tarball_name/name" ]]; then
-    bosh_interpolate "${root_dir}" "${release_name}" "$(cat ${root_dir}/release_tarball_name/name)"
+    bosh_interpolate "${root_dir}" "${release_name}" "${release_version}" "$(cat ${root_dir}/release_tarball_name/name)"
   else
     bosh_interpolate "${root_dir}" "${release_name}"
   fi

--- a/bosh-deploy-with-created-release/task
+++ b/bosh-deploy-with-created-release/task
@@ -33,13 +33,21 @@ main() {
   setup_bosh_env_vars
 
   local release_name
-  release_name="$(yq -r '.name' release/config/final.yml)"
-  if [[ "${release_name}" == "null" ]]; then
-    release_name="$(yq -r '.final_name' release/config/final.yml)"
-  fi
-  if [[ "${release_name}" == "null" ]]; then
-    echo "Expected non-empty 'name' or 'final_name' in release/config/final.yml"
-    exit 1
+  if [[ -n ${RELEASE_NAME_OF_TARBALL} ]]; then
+    if [[ ! -r "${root_dir}/release_tarball_name/name" ]]; then
+      echo "When providing 'RELEASE_NAME_OF_TARBALL', 'release_tarball_name' must be given."
+      exit 1
+    fi
+    release_name=${RELEASE_NAME_OF_TARBALL}
+  else
+    release_name="$(yq -r '.name' release/config/final.yml)"
+    if [[ "${release_name}" == "null" ]]; then
+      release_name="$(yq -r '.final_name' release/config/final.yml)"
+    fi
+    if [[ "${release_name}" == "null" ]]; then
+      echo "Expected non-empty 'name' or 'final_name' in release/config/final.yml"
+      exit 1
+    fi
   fi
 
   if [[ -r "${root_dir}/release_tarball_name/name" ]]; then

--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -44,6 +44,12 @@ params:
   # - Filepath to the manifest file within the cf-deployment resource
   # - The path is relative to root of the `cf-deployment` input
 
+  RELEASE_NAME_OF_TARBALL:
+  # - Optional
+  # - The name of the release, which was provided as a tarball
+  # - Required when deploying a release from a tarball, which was provided
+  #   using the input `release_tarball_name`.
+
   SYSTEM_DOMAIN:
   # - Required unless toolsmiths-env optional input is provided
   # - CF system base domain e.g. `my-cf.com`

--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -50,6 +50,12 @@ params:
   # - Required when deploying a release from a tarball, which was provided
   #   using the input `release_tarball_name`.
 
+  RELEASE_VERSION_OF_TARBALL:
+  # - Optional
+  # - The version of the release, which was provided as a tarball
+  # - Required when deploying a release from a tarball, which was provided
+  #   using the input `release_tarball_name`.
+
   SYSTEM_DOMAIN:
   # - Required unless toolsmiths-env optional input is provided
   # - CF system base domain e.g. `my-cf.com`

--- a/shared-functions
+++ b/shared-functions
@@ -133,7 +133,7 @@ function bosh_interpolate() {
       cat << EOF > create-provided-release.yml
 ---
 - type: replace
-  path: /releases/name=${release_name}
+  path: /releases/name=${release_name}?
   value:
     name: ${release_name}
     url: file://${root_dir}/release/${release_tarball_name}
@@ -142,7 +142,7 @@ EOF
       cat << EOF > create-provided-release.yml
 ---
 - type: replace
-  path: /releases/name=${release_name}
+  path: /releases/name=${release_name}?
   value:
     name: ${release_name}
     version: create

--- a/shared-functions
+++ b/shared-functions
@@ -108,8 +108,11 @@ function bosh_interpolate() {
   local release_name
   release_name="${2}"
 
+  local release_version
+  release_version="${3}"
+
   local release_tarball_name
-  release_tarball_name="${3}"
+  release_tarball_name="${4}"
   set -u
 
   local bosh_manifest
@@ -137,6 +140,7 @@ function bosh_interpolate() {
   value:
     name: ${release_name}
     url: file://${root_dir}/release/${release_tarball_name}
+    version: ${release_version}
 EOF
     else
       cat << EOF > create-provided-release.yml


### PR DESCRIPTION
### What is this change about?

The bosh-deploy-with-created-release task did not seem to work with a release tarball. The bash script was looking for a final.yml in the config folder, which is both not present when providing the release as a tarball.

I added two input parameters to the task: `RELEASE_NAME_OF_TARBALL`, which is the name of the release, which has been provided as a tarball and `RELEASE_VERSION_OF_TARBALL`, which is the version of that release. Both is needed to construct the ops file, to add the release to the deployment.yml.

The shared function `bosh_interpolate` needed some changes as well, to support the new version parameter.

### Please provide contextual information.

I found #96, which also mentions about this problem, which seems to have never been fully resolved.

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Fixed use case of `bosh-deploy-with-created-release` task, where a release has been provided as a tarball.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
