### PR TITLE
Remove deprecated ginkgo flag from CATs run

### DIFF
--- a/run-cats/task
+++ b/run-cats/task
@@ -52,7 +52,6 @@ export CF_PLUGIN_HOME=$HOME
   --keep-going \
   --randomize-all \
   --skip-package=helpers \
-  --slow-spec-threshold="${SLOW_SPEC_THRESHOLD}" \
   --nodes="${NODES}" \
   --skip="${SKIP_REGEXP}" \
   --flake-attempts=${FLAKE_ATTEMPTS} \

--- a/run-cats/task.yml
+++ b/run-cats/task.yml
@@ -22,10 +22,6 @@ run:
   path: cf-deployment-concourse-tasks/run-cats/task
 
 params:
-  SLOW_SPEC_THRESHOLD: 315s
-  # - Optional
-  # - The amount of time, as a Golang time.Duration, to wait before marking a test as slow.
-
   NODES: 12
   # - Optional
   # - Number of parallel ginkgo nodes.


### PR DESCRIPTION
### What is this change about?

* Removes `--slow-spec-threshold` flag.
* Removes SLOW_SPEC_THRESHOLD param from task.
* Gets rid of annoying warning message at the end of CATs runs.
* Prepares us for the flag being ripped out at any point

### Please provide contextual information.

Warning message from ginkgo when this flag is used:
```
You're using deprecated Ginkgo functionality:
=============================================
  --slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.
```

### Please check all that apply for this PR:

- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How should this change be described in release notes?

Remove slow spec threshold option from run-cats task, as it's deprecated by ginkgo.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None.