### PR TITLE
Update bbl-destroy task

### DIFF
--- a/bbl-destroy/task
+++ b/bbl-destroy/task
@@ -24,8 +24,7 @@ function main() {
     bbl \
       --debug \
       destroy \
-      --no-confirm \
-      --skip-if-missing > "${root_dir}"/bbl_destroy.txt
+      --no-confirm > "${root_dir}"/bbl_destroy.txt
   popd
 }
 


### PR DESCRIPTION
### What is this change about?

Removes `--skip-if-missing` flag, which was removed from the `bbl` CLI.

### Please provide contextual information.

* [bbl commit removing it](https://github.com/cloudfoundry/bosh-bootloader/commit/0e2b566dee7ded01069adce34f00db9c40ee20e1)

### Please check all that apply for this PR:

- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None