### PR TITLE
Migrate git user/mail configuration to ARD WG

### DIFF
--- a/ci/tasks/bump-cf-d-ct-docker-image/task
+++ b/ci/tasks/bump-cf-d-ct-docker-image/task
@@ -12,8 +12,8 @@ function commit_with_message() {
       return
     fi
 
-    git config user.name "CF RELINT BOT"
-    git config user.email "cf-release-integration@pivotal.io"
+    git config user.name "ARD WG Bot"
+    git config user.email "app-deployments@cloudfoundry.org"
 
     git add .
 

--- a/ci/tasks/update-cf-d-ct-dockerfile-versions/task
+++ b/ci/tasks/update-cf-d-ct-dockerfile-versions/task
@@ -12,8 +12,8 @@ sed -i "s/ENV uptimer_version.*$/ENV uptimer_version $(git -C uptimer rev-parse 
 
 pushd cf-deployment-concourse-tasks
   if [[ -n $(git status --porcelain) ]]; then
-    git config user.name "CI Bot"
-    git config user.email "cf-release-integration@pivotal.io"
+    git config user.name "ARD WG Bot"
+    git config user.email "app-deployments@cloudfoundry.org"
     git add .
     git commit --allow-empty \
     -m "Update Dockerfile"


### PR DESCRIPTION
### What is this change about?

Update the git user and mail configuration for the "cf-deployment-concourse-tasks" CI pipeline.

### Please provide contextual information.

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

Tasks are only used for cf-deployment-concourse-tasks CI pipeline: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment-concourse-tasks

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

No update necessary, the two changed tasks are not documented in the README.

### How should this change be described in release notes?

Not relevant for release notes.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
