### PR TITLE
Add uptimer tcp availability config to bosh deploy tasks

### DIFF
--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -96,9 +96,20 @@ params:
   # - Requires DEPLOY_WITH_UPTIME_MEASUREMENTS to be true.
   # - This will measure availability of app syslog drain during deployment.
 
+  MEASURE_TCP_AVAILABILITY: false
+  # - Optional
+  # - Requires DEPLOY_WITH_UPTIME_MEASUREMENTS to be true.
+  # - This will measure availability of TCP routing during deployment.
+
   TCP_DOMAIN:
-  # - Required if MEASURE_SYSLOG_AVAILABILITY is set to true.
-  # - Domain in which to create a tcp route for the syslog availability measurement.
+  # - Required if MEASURE_TCP_AVAILABILITY or MEASURE_SYSLOG_AVAILABILITY is set to true.
+  # - Domain used by CF for creating tcp routes to apps, syslog.
+  # - Usually of the form `tcp.[SYSTEM_DOMAIN]` (e.g. `tcp.my-cf.com`).
+
+  TCP_PORT:
+  # - Required if MEASURE_TCP_AVAILABILITY is set to true.
+  # - Available port within the 'reservable_ports' range,
+  # - used to create a tcp route for TCP routing availability measurement.
 
   AVAILABLE_PORT:
   # - Required if MEASURE_SYSLOG_AVAILABILITY is set to true.
@@ -113,6 +124,11 @@ params:
   HTTP_AVAILABILITY_THRESHOLD: 0
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for http availability
+  # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+
+  TCP_AVAILABILITY_THRESHOLD: 0
+  # - Optional
+  # - This sets the maximum number of allowed uptimer failures for tcp availability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
 
   RECENT_LOGS_THRESHOLD: 0

--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -102,7 +102,8 @@ params:
   # - This will measure availability of TCP routing during deployment.
 
   TCP_DOMAIN:
-  # - Required if MEASURE_TCP_AVAILABILITY or MEASURE_SYSLOG_AVAILABILITY is set to true.
+  # - Required if MEASURE_TCP_AVAILABILITY or MEASURE_SYSLOG_AVAILABILITY is set to true,
+  #   unless toolsmiths-env is provided. With toolsmiths-env, this value is automatically calculated.
   # - Domain used by CF for creating tcp routes to apps, syslog.
   # - Usually of the form `tcp.[SYSTEM_DOMAIN]` (e.g. `tcp.my-cf.com`).
 

--- a/bosh-deploy-with-updated-release-submodule/task.yml
+++ b/bosh-deploy-with-updated-release-submodule/task.yml
@@ -84,9 +84,21 @@ params:
   # - Requires DEPLOY_WITH_UPTIME_MEASUREMENTS to be true.
   # - This will measure availability of app syslog drain during deployment.
 
+  MEASURE_TCP_AVAILABILITY: false
+  # - Optional
+  # - Requires DEPLOY_WITH_UPTIME_MEASUREMENTS to be true.
+  # - This will measure availability of TCP routing during deployment.
+
   TCP_DOMAIN:
-  # - Required if MEASURE_SYSLOG_AVAILABILITY is set to true.
-  # - Domain in which to create a tcp route for the syslog availability measurement.
+  # - Required if MEASURE_TCP_AVAILABILITY or MEASURE_SYSLOG_AVAILABILITY is set to true.
+  # - Domain used by CF for creating tcp routes to apps, syslog.
+  # - Usually of the form `tcp.[SYSTEM_DOMAIN]` (e.g. `tcp.my-cf.com`).
+
+  TCP_PORT:
+  # - Required if MEASURE_TCP_AVAILABILITY is set to true.
+  # - Available port within the 'reservable_ports' range,
+  # - used to create a tcp route for TCP routing availability measurement.
+
 
   AVAILABLE_PORT:
   # - Required if MEASURE_SYSLOG_AVAILABILITY is set to true.
@@ -101,6 +113,11 @@ params:
   HTTP_AVAILABILITY_THRESHOLD: 0
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for http availability
+  # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+
+  TCP_AVAILABILITY_THRESHOLD: 0
+  # - Optional
+  # - This sets the maximum number of allowed uptimer failures for tcp availability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
 
   RECENT_LOGS_THRESHOLD: 0

--- a/bosh-deploy-with-updated-release-submodule/task.yml
+++ b/bosh-deploy-with-updated-release-submodule/task.yml
@@ -90,7 +90,8 @@ params:
   # - This will measure availability of TCP routing during deployment.
 
   TCP_DOMAIN:
-  # - Required if MEASURE_TCP_AVAILABILITY or MEASURE_SYSLOG_AVAILABILITY is set to true.
+  # - Required if MEASURE_TCP_AVAILABILITY or MEASURE_SYSLOG_AVAILABILITY is set to true,
+  #   unless toolsmiths-env is provided. With toolsmiths-env, this value is automatically calculated.
   # - Domain used by CF for creating tcp routes to apps, syslog.
   # - Usually of the form `tcp.[SYSTEM_DOMAIN]` (e.g. `tcp.my-cf.com`).
 

--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -74,9 +74,20 @@ params:
   # - Requires DEPLOY_WITH_UPTIME_MEASUREMENTS to be true.
   # - This will measure availability of app syslog drain during deployment.
 
+  MEASURE_TCP_AVAILABILITY: false
+  # - Optional
+  # - Requires DEPLOY_WITH_UPTIME_MEASUREMENTS to be true.
+  # - This will measure availability of TCP routing during deployment.
+
   TCP_DOMAIN:
-  # - Required if MEASURE_SYSLOG_AVAILABILITY is set to true.
-  # - Domain in which to create a tcp route for the syslog availability measurement.
+  # - Required if MEASURE_TCP_AVAILABILITY or MEASURE_SYSLOG_AVAILABILITY is set to true.
+  # - Domain used by CF for creating tcp routes to apps, syslog.
+  # - Usually of the form `tcp.[SYSTEM_DOMAIN]` (e.g. `tcp.my-cf.com`).
+
+  TCP_PORT:
+  # - Required if MEASURE_TCP_AVAILABILITY is set to true.
+  # - Available port within the 'reservable_ports' range,
+  # - used to create a tcp route for TCP routing availability measurement.
 
   AVAILABLE_PORT:
   # - Required if MEASURE_SYSLOG_AVAILABILITY is set to true.
@@ -96,6 +107,11 @@ params:
   HTTP_AVAILABILITY_THRESHOLD: 0
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for http availability
+  # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+
+  TCP_AVAILABILITY_THRESHOLD: 0
+  # - Optional
+  # - This sets the maximum number of allowed uptimer failures for tcp availability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
 
   RECENT_LOGS_THRESHOLD: 0

--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -80,7 +80,8 @@ params:
   # - This will measure availability of TCP routing during deployment.
 
   TCP_DOMAIN:
-  # - Required if MEASURE_TCP_AVAILABILITY or MEASURE_SYSLOG_AVAILABILITY is set to true.
+  # - Required if MEASURE_TCP_AVAILABILITY or MEASURE_SYSLOG_AVAILABILITY is set to true,
+  #   unless toolsmiths-env is provided. With toolsmiths-env, this value is automatically calculated.
   # - Domain used by CF for creating tcp routes to apps, syslog.
   # - Usually of the form `tcp.[SYSTEM_DOMAIN]` (e.g. `tcp.my-cf.com`).
 

--- a/shared-functions
+++ b/shared-functions
@@ -180,10 +180,13 @@ write_uptimer_deploy_config() {
   # jq as bosh deploy args
   shift 2
 
-  # Give bogus values for TCP_DOMAIN and AVAILABLE_PORT
-  # so that we don't have to do jq magic.
+  # Give bogus values for TCP_DOMAIN, TCP_PORT, and
+  # AVAILABLE_PORT so that we don't have to do jq magic.
+
   local tcp_domain
   tcp_domain=${TCP_DOMAIN:-" "}
+  local tcp_port
+  tcp_port=${TCP_PORT:-"-1"}
   local available_port
   available_port=${AVAILABLE_PORT:-"-1"}
 
@@ -198,10 +201,13 @@ write_uptimer_deploy_config() {
     --arg manifest ${manifest} \
     --arg deployment_name ${deployment_name} \
     --arg run_app_syslog_availability ${MEASURE_SYSLOG_AVAILABILITY} \
+    --arg run_tcp_availability ${MEASURE_TCP_AVAILABILITY} \
     --arg tcp_domain "${tcp_domain}" \
+    --arg tcp_port ${tcp_port} \
     --arg available_port ${available_port} \
     --arg app_pushability ${APP_PUSHABILITY_THRESHOLD} \
     --arg http_availability ${HTTP_AVAILABILITY_THRESHOLD} \
+    --arg tcp_availability ${TCP_AVAILABILITY_THRESHOLD} \
     --arg recent_logs ${RECENT_LOGS_THRESHOLD} \
     --arg streaming_logs ${STREAMING_LOGS_THRESHOLD} \
     --arg use_single_app_instance ${USE_SINGLE_APP_INSTANCE} \
@@ -219,17 +225,20 @@ write_uptimer_deploy_config() {
         "admin_password": $admin_password,
         "tcp_domain": $tcp_domain,
         "available_port": $available_port | tonumber,
+        "tcp_port": $tcp_port | tonumber,
         "use_single_app_instance": $use_single_app_instance | ascii_downcase | contains("true")
       },
       "allowed_failures": {
         "app_pushability": $app_pushability | tonumber,
         "http_availability": $http_availability | tonumber,
+        "tcp_availability": $tcp_availability | tonumber,
         "recent_logs": $recent_logs | tonumber,
         "streaming_logs": $streaming_logs | tonumber,
         "app_syslog_availability": $app_syslog_availability | tonumber
       },
       "optional_tests": {
-        "run_app_syslog_availability": $run_app_syslog_availability | ascii_downcase | contains("true")
+        "run_app_syslog_availability": $run_app_syslog_availability | ascii_downcase | contains("true"),
+        "run_tcp_availability": $run_tcp_availability | ascii_downcase | contains("true")
       }
     }' \
     -- ${@}

--- a/shared-functions
+++ b/shared-functions
@@ -87,6 +87,7 @@ function setup_bosh_env_vars() {
   if [ -d toolsmiths-env ]; then
     eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
     export SYSTEM_DOMAIN="$(cat toolsmiths-env/name).cf-app.com"
+    export TCP_DOMAIN="tcp.${SYSTEM_DOMAIN}"
   else
     if [ -d bbl-state ]; then
       pushd "bbl-state/${BBL_STATE_DIR}"


### PR DESCRIPTION
### What is this change about?
This PR to the `cf-deployment-concourse-tasks` updates the `uptimer` config writing process to include the TCP availability measurement changes introduced to `uptimer` in https://github.com/cloudfoundry/uptimer/pull/27. These changes allow consumers of `cf-deployment-concourse-tasks` to configure any of the three `bosh-deploy` tasks to measure TCP availability to an app on the foundation with `uptimer` during a deployment. This change also automatically calculates the TCP domain of a Toolsmiths env, if provided, instead of explicitly requiring the TCP domain to be configured at the concourse task param level.

These changes are useful for testing the availability of TCP when we are performing deployments that cause downtime to the TCP router.

#### Release consideration
Measuring TCP availability correctly also depends on an `uptimer` bugfix: https://github.com/cloudfoundry/uptimer/pull/41
That fix needs to be merged, a new version of `uptimer` created and then subsequently consumed by `cf-deployment-concourse-tasks` before a new release of `cf-deployment-concourse-tasks` can be created.

### Please provide contextual information.
- https://github.com/cloudfoundry/uptimer/pull/27
- https://www.pivotaltracker.com/story/show/183976643

- https://github.com/cloudfoundry/uptimer/pull/41

### Please check all that apply for this PR:
- [ ] introduces a new task
- [X] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A

I updated the comments in the concourse task yaml themselves.

### How should this change be described in release notes?
Updates bosh deploy tasks' configuration to allow uptime measurement of TCP availability.


### What is the level of urgency for publishing this change?
- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
Github team:
- https://github.com/orgs/cloudfoundry/teams/wg-app-runtime-platform
- https://github.com/orgs/pivotal/teams/runtime

Slack:
[CF #wg-app-runtime-platform](https://cloudfoundry.slack.com/archives/C02HNDJB31R)
or 
`#tas-containers-and-connectivity`