### PR TITLE
Fix: bbl-up task

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -124,6 +124,10 @@ function main() {
 
     if [[ "${DELETE_TERRAFORM_PLUGINS}" == "true" ]]; then
       rm -rf "terraform/.terraform"
+    else
+      pushd "terraform"
+        terraform init
+      popd
     fi
   popd
 }


### PR DESCRIPTION
### What is this change about?

Calls `terraform init` in `bbl-up` task if `DELETE_TERRAFORM_PLUGINS` is set to `false`. This should ensure that certain bbl commands, that require the correct plugins, work

### Please provide contextual information.

https://github.com/cloudfoundry/bosh-bootloader/issues/560

### Please check all that apply for this PR:

- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How should this change be described in release notes?

Fix issues related to running certain `bbl` commands by running `terraform init` beforehand.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None