### PR TITLE
Fix: bbl download link in dockerfile

### DIFF
--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -82,7 +82,7 @@ RUN set -eux; \
 
 # bbl
 RUN set -eux; \
-      url="https://github.com/cloudfoundry/bosh-bootloader/releases/download/v${bbl_version}/bbl-v${bbl_version}_linux_x86-64"; \
+      url="https://github.com/cloudfoundry/bosh-bootloader/releases/download/v${bbl_version}/bbl-v${bbl_version}_linux_amd64"; \
       wget -O /usr/local/bin/bbl "${url}"; \
       chmod +x /usr/local/bin/bbl; \
       bbl version


### PR DESCRIPTION
### What is this change about?

Recent bbl releases use a different postfix for the linux binary.

### Please provide contextual information.

https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment-concourse-tasks/jobs/build-docker-image/builds/137

### Please check all that apply for this PR:

- [ ] introduces a new task
- [ ] changes an existing task
- [x] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How should this change be described in release notes?

N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None