### PR TITLE
Fix bbl executable name

### DIFF
--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -82,7 +82,7 @@ RUN set -eux; \
 
 # bbl
 RUN set -eux; \
-      url="https://github.com/cloudfoundry/bosh-bootloader/releases/download/v${bbl_version}/bbl-v${bbl_version}_linux_x86-64"; \
+      url="https://github.com/cloudfoundry/bosh-bootloader/releases/download/v${bbl_version}/bbl-v${bbl_version}_linux_amd64"; \
       wget -O /usr/local/bin/bbl "${url}"; \
       chmod +x /usr/local/bin/bbl; \
       bbl version


### PR DESCRIPTION
* was renamed, see assets of https://github.com/cloudfoundry/bosh-bootloader/releases/tag/v9.0.7

### What is this change about?

Fix decota Docker image build.

### Please provide contextual information.

Build is broken because bbl executable has been renamed: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment-concourse-tasks/jobs/build-docker-image/builds/140

### Please check all that apply for this PR:
- [ ] introduces a new task
- [ ] changes an existing task
- [x] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in release notes?

Not relevant.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
