### PR TITLE
Update bosh-deploy-with-created-release to build a valid manifest when specifying a release tarball

### DIFF
--- a/shared-functions
+++ b/shared-functions
@@ -131,13 +131,16 @@ function bosh_interpolate() {
 
   if [ -n "${release_name}" ]; then
     if [ -n "${release_tarball_name}" ]; then
+      tarball_path="${root_dir}/release/${release_tarball_name}"
+      version=$(tar xzf "${tarball_path}" -O release.MF | yq -r '.version // "latest"')
       cat << EOF > create-provided-release.yml
 ---
 - type: replace
   path: /releases/name=${release_name}
   value:
     name: ${release_name}
-    url: file://${root_dir}/release/${release_tarball_name}
+    url: file://${tarball_path}
+    version: ${version}
 EOF
     else
       cat << EOF > create-provided-release.yml


### PR DESCRIPTION
Update bosh_interpolate to pull release version info from the provided tarball to avoid bosh manifest errors

### What is this change about?

When providing a release tarball to  bosh-deploy-with-created-release, the resultant manifest doesn't include a `version` directive for the release, and bosh fails to validate the manifest.

### Please provide contextual information.

If you're able to see it, this breaks the [windows-roofts pipeline](https://ci.funtime.lol/teams/garden-windows/pipelines/windows-rootfs/jobs/offline-smoke-tests/builds/18), and we're trying to consolidate onto common tasks instead of previously used release-specific tasks that didn't suffer from this issue. 

This is a much smaller fix in scope than #139, but if that is deemed preferable, this one is likely not needed.

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Fixes an issue with `bosh-deploy-with-created-release` where passing a release_tarball_name would result in an invalid BOSH manifest, and deployments would fail.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
