### PR TITLE
Use metadata file instead of name file

### DIFF
--- a/shared-functions
+++ b/shared-functions
@@ -86,7 +86,7 @@ function setup_bosh_env_vars() {
   set +x
   if [ -d toolsmiths-env ]; then
     eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
-    export SYSTEM_DOMAIN="$(cat toolsmiths-env/name).cf-app.com"
+    export SYSTEM_DOMAIN="$(cat toolsmiths-env/metadata | jq -r .name).cf-app.com"
     export TCP_DOMAIN="tcp.${SYSTEM_DOMAIN}"
   else
     if [ -d bbl-state ]; then


### PR DESCRIPTION
This allows for compatibility with other pooled environment providers

### What is this change about?

Toolsmiths provides two ways to fetch the name of the an environment:
1. The `name` file, which is currently used
2. The `metadata` file, which is a json file with the environment name saved in the top-level `name` field.

This change switches to the second implementation, as other pooled environment providers have maintained the same `metadata` file schema for compatibility.


### Please provide contextual information.

N/A



### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Use `metadata` file instead of `name` file to fetch environment name



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
