### PR TITLE
Fix missing \ for multiline command

### DIFF
--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux; \
 
 # credhub
 RUN set -eux; \
-      url="https://github.com/cloudfoundry/credhub-cli/releases/download/${credhub_cli_version}/credhub-linux-amd64-${credhub_cli_version}.tgz"
+      url="https://github.com/cloudfoundry/credhub-cli/releases/download/${credhub_cli_version}/credhub-linux-amd64-${credhub_cli_version}.tgz" \
       wget -O credhub.tgz "${url}"; \
       tar -C /usr/local/bin -xzf credhub.tgz; \
       rm credhub.tgz; \


### PR DESCRIPTION
### What is this change about?

Fix missing "\" in multiline command, was introduced with https://github.com/cloudfoundry/cf-deployment-concourse-tasks/pull/162

### Please provide contextual information.

https://github.com/cloudfoundry/cf-deployment-concourse-tasks/pull/162

### Please check all that apply for this PR:
- [ ] introduces a new task
- [ ] changes an existing task
- [x] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in release notes?

N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
