### PR TITLE
Fix(dockerfile): typo in downloading credhub CLI

### DIFF
--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux; \
 
 # credhub
 RUN set -eux; \
-      url="https://github.com/cloudfoundry/credhub-cli/releases/download/${credhub_cli_version}/credhub-linux-amd64-${credhub_cli_version}.tgz" \
+      url="https://github.com/cloudfoundry/credhub-cli/releases/download/${credhub_cli_version}/credhub-linux-amd64-${credhub_cli_version}.tgz"; \
       wget -O credhub.tgz "${url}"; \
       tar -C /usr/local/bin -xzf credhub.tgz; \
       rm credhub.tgz; \


### PR DESCRIPTION
### What is this change about?

The url var assignment was missing a semi-colon to delimit the command.

### Please provide contextual information.

* https://github.com/cloudfoundry/cf-deployment-concourse-tasks/pull/162
* https://github.com/cloudfoundry/cf-deployment-concourse-tasks/pull/163

### Please check all that apply for this PR:

- [ ] introduces a new task
- [ ] changes an existing task
- [x] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None