### PR TITLE
Feat(dockerfile): Upgrade to bullseye

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -58,6 +58,14 @@ resources:
     repository: terraform
     access_token: ((ard_wg_gitbot_token))
 
+- name: yq-github-release
+  type: github-release
+  icon: github
+  source:
+    user: mikefarah
+    repository: yq
+    access_token: ((ard_wg_gitbot_token))
+
 - name: uptimer
   type: git
   icon: github
@@ -128,6 +136,8 @@ jobs:
     - get: uptimer
       trigger: true
     - get: bbl-github-release
+      trigger: true
+    - get: yq-github-release
       trigger: true
   - task: update-dockerfile-versions
     file: cf-deployment-concourse-tasks-dockerfile/ci/tasks/update-cf-d-ct-dockerfile-versions/task.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -121,11 +121,13 @@ jobs:
   public: true
   plan:
   - in_parallel:
-    - get: cf-deployment-concourse-tasks-dockerfile
+    - get: bbl-github-release
       trigger: true
     - get: bosh-cli-github-release
       trigger: true
     - get: cf-cli-github-release
+      trigger: true
+    - get: cf-deployment-concourse-tasks-dockerfile
       trigger: true
     - get: credhub-cli-github-release
       trigger: true
@@ -134,8 +136,6 @@ jobs:
     - get: terraform-github-release
       trigger: true
     - get: uptimer
-      trigger: true
-    - get: bbl-github-release
       trigger: true
     - get: yq-github-release
       trigger: true

--- a/ci/tasks/update-cf-d-ct-dockerfile-versions/task
+++ b/ci/tasks/update-cf-d-ct-dockerfile-versions/task
@@ -2,12 +2,12 @@
 
 dockerfile="cf-deployment-concourse-tasks/dockerfiles/cf-deployment-concourse-tasks/Dockerfile"
 
+sed -i "s/ENV bbl_version.*$/ENV bbl_version $(cat bbl-github-release/version)/" $dockerfile
 sed -i "s/ENV bosh_cli_version.*$/ENV bosh_cli_version $(cat bosh-cli-github-release/version)/" $dockerfile
-sed -i "s/ENV terraform_version.*$/ENV terraform_version $(cat terraform-github-release/version)/" $dockerfile
+sed -i "s/ENV cf_cli_version.*$/ENV cf_cli_version $(cat cf-cli/version)/" $dockerfile
 sed -i "s/ENV credhub_cli_version.*$/ENV credhub_cli_version $(cat credhub-cli-github-release/version)/" $dockerfile
 sed -i "s/ENV log_cache_cli_version.*$/ENV log_cache_cli_version $(cat log-cache-cli-github-release/version)/" $dockerfile
-sed -i "s/ENV cf_cli_version.*$/ENV cf_cli_version $(cat cf-cli/version)/" $dockerfile
-sed -i "s/ENV bbl_version.*$/ENV bbl_version $(cat bbl-github-release/version)/" $dockerfile
+sed -i "s/ENV terraform_version.*$/ENV terraform_version $(cat terraform-github-release/version)/" $dockerfile
 sed -i "s/ENV uptimer_version.*$/ENV uptimer_version $(git -C uptimer rev-parse HEAD)/" $dockerfile
 sed -i "s/ENV yq_version.*$/ENV yq_version $(cat yq-github-release/version)/" $dockerfile
 

--- a/ci/tasks/update-cf-d-ct-dockerfile-versions/task
+++ b/ci/tasks/update-cf-d-ct-dockerfile-versions/task
@@ -9,6 +9,7 @@ sed -i "s/ENV log_cache_cli_version.*$/ENV log_cache_cli_version $(cat log-cache
 sed -i "s/ENV cf_cli_version.*$/ENV cf_cli_version $(cat cf-cli/version)/" $dockerfile
 sed -i "s/ENV bbl_version.*$/ENV bbl_version $(cat bbl-github-release/version)/" $dockerfile
 sed -i "s/ENV uptimer_version.*$/ENV uptimer_version $(git -C uptimer rev-parse HEAD)/" $dockerfile
+sed -i "s/ENV yq_version.*$/ENV yq_version $(cat yq-github-release/version)/" $dockerfile
 
 pushd cf-deployment-concourse-tasks
   if [[ -n $(git status --porcelain) ]]; then

--- a/ci/tasks/update-cf-d-ct-dockerfile-versions/task.yml
+++ b/ci/tasks/update-cf-d-ct-dockerfile-versions/task.yml
@@ -7,14 +7,14 @@ image_resource:
     repository: cloudfoundry/relint-base
 
 inputs:
-- name: cf-deployment-concourse-tasks
+- name: bbl-github-release
 - name: bosh-cli-github-release
+- name: cf-cli
+- name: cf-deployment-concourse-tasks
 - name: credhub-cli-github-release
 - name: log-cache-cli-github-release
-- name: cf-cli
 - name: terraform-github-release
 - name: uptimer
-- name: bbl-github-release
 - name: yq-github-release
 
 outputs:

--- a/ci/tasks/update-cf-d-ct-dockerfile-versions/task.yml
+++ b/ci/tasks/update-cf-d-ct-dockerfile-versions/task.yml
@@ -15,6 +15,7 @@ inputs:
 - name: terraform-github-release
 - name: uptimer
 - name: bbl-github-release
+- name: yq-github-release
 
 outputs:
 - name: cf-deployment-concourse-tasks-updated

--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5-buster
+FROM golang:1.20.8-bullseye
 
 ENV JQ_VERSION 1.6
 ENV JQ_CHECKSUM 056ba5d6bbc617c29d37158ce11fd5a443093949
@@ -27,8 +27,8 @@ RUN set -eux; \
       apt-get -y install ruby-full; \
       apt-get remove -y --purge software-properties-common
 
-# assert ruby 2.5 is installed
-RUN ruby --version | grep 2\.5
+# assert ruby 2.7 is installed
+RUN ruby --version | grep 2\.7
 
 # jq
 RUN set -eux; \
@@ -44,17 +44,17 @@ RUN pip3 install yq
 RUN set -eux; \
       apt-get -y install \
         build-essential \
-        libreadline6-dev \
-        libreadline7 \
+        libreadline-dev \
         libsqlite3-dev \
         libssl-dev \
         libxml2-dev \
-        libxslt-dev \
+        libxslt1-dev \
         libyaml-dev \
         openssl \
-        sqlite \
-        zlib1g-dev \
-        zlibc; \
+        ruby \
+        ruby-dev \
+        sqlite3 \
+        zlib1g-dev; \
       url="https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64"; \
       wget -O /usr/local/bin/bosh "${url}"; \
       chmod +x /usr/local/bin/bosh; \

--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -12,20 +12,16 @@ ENV git_crypt_version 0.7.0
 ENV log_cache_cli_version 5.0.4
 ENV uptimer_version f5f8149b8977e030b60b5fde37e54db8af4025cc
 
+RUN apt-get update
+
+# utils
 RUN set -eux; \
-      apt-get update; \
       apt-get -y install \
-        apt-utils \
-        curl \
-        git \
         netcat-openbsd \
         python3-pip \
-        software-properties-common \
+        ruby-full \
         unzip \
-        vim \
-        wget; \
-      apt-get -y install ruby-full; \
-      apt-get remove -y --purge software-properties-common
+        vim;
 
 # assert ruby 2.7 is installed
 RUN ruby --version | grep 2\.7

--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:1.20.8-bullseye
 
-ENV JQ_VERSION 1.6
-ENV JQ_CHECKSUM 056ba5d6bbc617c29d37158ce11fd5a443093949
-
 ENV cf_cli_version 8.7.3
 ENV bosh_cli_version 7.4.0
 ENV bbl_version 9.0.12
@@ -17,6 +14,7 @@ RUN apt-get update
 # useful utils
 RUN set -eux; \
       apt-get -y install \
+        jq \
         netcat-openbsd \
         python3-pip \
         unzip \
@@ -26,13 +24,6 @@ RUN set -eux; \
 RUN set -eux; \
       apt-get -y install ruby-full; \
       ruby --version | grep 2\.7
-
-# jq
-RUN set -eux; \
-      url="https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64"; \
-      wget -O /usr/local/bin/jq "${url}"; \
-      echo "${JQ_CHECKSUM} /usr/local/bin/jq" | sha1sum -c -; \
-      chmod +x /usr/local/bin/jq
 
 # yq
 RUN pip3 install yq

--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -4,7 +4,6 @@ ENV bbl_version 9.0.12
 ENV bosh_cli_version 7.4.0
 ENV cf_cli_version 8.7.3
 ENV credhub_cli_version 2.9.21
-ENV git_crypt_version 0.7.0
 ENV log_cache_cli_version 5.0.4
 ENV terraform_version 1.5.7
 ENV uptimer_version f5f8149b8977e030b60b5fde37e54db8af4025cc
@@ -15,6 +14,7 @@ RUN apt-get update
 # useful utils
 RUN set -eux; \
       apt-get -y install \
+        git-crypt \
         jq \
         netcat-openbsd \
         unzip \
@@ -90,12 +90,6 @@ RUN set -eux; \
       rm "${file}"; \
       chmod +x /usr/local/bin/terraform; \
       terraform version
-
-# git-crypt
-RUN set -eux; \
-      url="https://github.com/AGWA/git-crypt/releases/download/${git_crypt_version}/git-crypt-${git_crypt_version}-linux-x86_64"; \
-      wget -O /usr/local/bin/git-crypt "${url}"; \
-      chmod +x /usr/local/bin/git-crypt
 
 # log-cache
 RUN set -eux; \

--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -14,17 +14,18 @@ ENV uptimer_version f5f8149b8977e030b60b5fde37e54db8af4025cc
 
 RUN apt-get update
 
-# utils
+# useful utils
 RUN set -eux; \
       apt-get -y install \
         netcat-openbsd \
         python3-pip \
-        ruby-full \
         unzip \
         vim;
 
-# assert ruby 2.7 is installed
-RUN ruby --version | grep 2\.7
+# ruby
+RUN set -eux; \
+      apt-get -y install ruby-full; \
+      ruby --version | grep 2\.7
 
 # jq
 RUN set -eux; \

--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -1,13 +1,14 @@
 FROM golang:1.20.8-bullseye
 
-ENV cf_cli_version 8.7.3
-ENV bosh_cli_version 7.4.0
 ENV bbl_version 9.0.12
-ENV terraform_version 1.5.7
+ENV bosh_cli_version 7.4.0
+ENV cf_cli_version 8.7.3
 ENV credhub_cli_version 2.9.21
 ENV git_crypt_version 0.7.0
 ENV log_cache_cli_version 5.0.4
+ENV terraform_version 1.5.7
 ENV uptimer_version f5f8149b8977e030b60b5fde37e54db8af4025cc
+ENV yq_version 4.35.2
 
 RUN apt-get update
 
@@ -16,7 +17,6 @@ RUN set -eux; \
       apt-get -y install \
         jq \
         netcat-openbsd \
-        python3-pip \
         unzip \
         vim;
 
@@ -26,7 +26,10 @@ RUN set -eux; \
       ruby --version | grep 2\.7
 
 # yq
-RUN pip3 install yq
+RUN set -eux; \
+      wget "https://github.com/mikefarah/yq/releases/download/v${yq_version}/yq_linux_amd64" -O /usr/local/bin/yq; \
+      chmod +x /usr/local/bin/yq; \
+      yq --version
 
 # bosh
 RUN set -eux; \

--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -87,12 +87,6 @@ RUN set -eux; \
       chmod +x /usr/local/bin/bbl; \
       bbl version
 
-RUN \
-      wget https://github.com/cloudfoundry/bosh-bootloader/archive/v${bbl_version}.tar.gz -P /tmp && \
-      mkdir -p /var/repos/bosh-bootloader && \
-      tar xvf  /tmp/v${bbl_version}.tar.gz --strip-components=1 -C /var/repos/bosh-bootloader && \
-      rm -rf /tmp/*
-
 # terraform
 RUN set -eux; \
       file="terraform_${terraform_version}_linux_amd64.zip"; \

--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -27,7 +27,8 @@ RUN set -eux; \
 
 # yq
 RUN set -eux; \
-      wget "https://github.com/mikefarah/yq/releases/download/v${yq_version}/yq_linux_amd64" -O /usr/local/bin/yq; \
+      url="https://github.com/mikefarah/yq/releases/download/v${yq_version}/yq_linux_amd64"; \
+      wget "${url}" -O /usr/local/bin/yq; \
       chmod +x /usr/local/bin/yq; \
       yq --version
 
@@ -42,68 +43,69 @@ RUN set -eux; \
         libxslt1-dev \
         libyaml-dev \
         openssl \
-        ruby \
-        ruby-dev \
         sqlite3 \
         zlib1g-dev; \
-      url="https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64"; \
-      wget -O /usr/local/bin/bosh "${url}"; \
+      url="https://github.com/cloudfoundry/bosh-cli/releases/download/v${bosh_cli_version}/bosh-cli-${bosh_cli_version}-linux-amd64"; \
+      wget "${url}" -O /usr/local/bin/bosh; \
       chmod +x /usr/local/bin/bosh; \
       bosh --version
 
 # cf
 RUN set -eux; \
+      mkdir -p /tmp/cf; \
       url="https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${cf_cli_version}"; \
-      wget -O cf.tgz "${url}"; \
-      mkdir /tmp/cf; \
-      tar -C /tmp/cf -xzf cf.tgz; \
-      rm cf.tgz; \
+      wget "${url}" -O /tmp/cf/cf.tgz; \
+      tar -xzf /tmp/cf/cf.tgz -C /tmp/cf; \
       mv /tmp/cf/cf8 /usr/local/bin/cf; \
-      rm -r /tmp/cf; \
       chmod +x /usr/local/bin/cf; \
-      cf version
+      cf version; \
+      rm -rf /tmp/cf
 
 # credhub
 RUN set -eux; \
+      mkdir -p /tmp/credhub; \
       url="https://github.com/cloudfoundry/credhub-cli/releases/download/${credhub_cli_version}/credhub-linux-amd64-${credhub_cli_version}.tgz"; \
-      wget -O credhub.tgz "${url}"; \
-      tar -C /usr/local/bin -xzf credhub.tgz; \
-      rm credhub.tgz; \
+      wget "${url}" -O /tmp/credhub/credhub.tgz; \
+      tar -xzf /tmp/credhub/credhub.tgz -C /tmp/credhub; \
+      mv /tmp/credhub/credhub /usr/local/bin; \
       chmod +x /usr/local/bin/credhub; \
-      credhub --version
+      credhub --version; \
+      rm -rf /tmp/credhub
 
 # bbl
 RUN set -eux; \
       url="https://github.com/cloudfoundry/bosh-bootloader/releases/download/v${bbl_version}/bbl-v${bbl_version}_linux_amd64"; \
-      wget -O /usr/local/bin/bbl "${url}"; \
+      wget "${url}" -O /usr/local/bin/bbl; \
       chmod +x /usr/local/bin/bbl; \
       bbl version
 
 # terraform
 RUN set -eux; \
-      file="terraform_${terraform_version}_linux_amd64.zip"; \
-      url="https://releases.hashicorp.com/terraform/${terraform_version}/${file}"; \
-      sha256="$(curl "https://releases.hashicorp.com/terraform/${terraform_version}/terraform_${terraform_version}_SHA256SUMS" | grep linux_amd64)"; \
-      wget -O "${file}" "${url}"; \
-      echo "${sha256}" | shasum -c -; \
-      unzip "${file}" -d /usr/local/bin; \
-      rm "${file}"; \
+      mkdir -p /tmp/terraform; \
+      url="https://releases.hashicorp.com/terraform/${terraform_version}/terraform_${terraform_version}_linux_amd64.zip"; \
+      wget "${url}" -O /tmp/terraform/terraform.zip; \
+      unzip /tmp/terraform/terraform.zip -d /tmp/terraform; \
+      mv /tmp/terraform/terraform /usr/local/bin; \
       chmod +x /usr/local/bin/terraform; \
-      terraform version
+      terraform version; \
+      rm -rf /tmp/terraform
 
 # log-cache
 RUN set -eux; \
       url="https://github.com/cloudfoundry/log-cache-cli/releases/download/v${log_cache_cli_version}/log-cache-cf-plugin-linux"; \
-      wget -O log-cache-plugin "${url}"; \
-      cf install-plugin log-cache-plugin -f; \
-      rm log-cache-plugin
+      wget "${url}" -O /tmp/log-cache-plugin; \
+      cf install-plugin /tmp/log-cache-plugin -f; \
+      rm /tmp/log-cache-plugin
 
 # uptimer
-RUN go install "github.com/cloudfoundry/uptimer@${uptimer_version}"
+RUN set -eux; \
+      go install "github.com/cloudfoundry/uptimer@${uptimer_version}"; \
+      uptimer -v
 
 # Add trusted relint ca certificate
 ARG RELINT_CA_CERTIFICATE
 ARG PREVIOUS_RELINT_CA_CERTIFICATE
-RUN echo -n "$RELINT_CA_CERTIFICATE" > /usr/local/share/ca-certificates/relint.crt && \
-    echo -n "$PREVIOUS_RELINT_CA_CERTIFICATE" > /usr/local/share/ca-certificates/previous_relint.crt && \
-  /usr/sbin/update-ca-certificates -f
+RUN set -e; \
+      echo -n "$RELINT_CA_CERTIFICATE" > /usr/local/share/ca-certificates/relint.crt; \
+      echo -n "$PREVIOUS_RELINT_CA_CERTIFICATE" > /usr/local/share/ca-certificates/previous_relint.crt; \
+      /usr/sbin/update-ca-certificates -f

--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -16,26 +16,14 @@ RUN set -eux; \
       apt-get update; \
       apt-get -y install \
         apt-utils \
-        build-essential \
         curl \
         git \
-        libreadline6-dev \
-        libreadline7 \
-        libsqlite3-dev \
-        libssl-dev \
-        libxml2-dev \
-        libxslt-dev \
-        libyaml-dev \
         netcat-openbsd \
-        openssl \
         python3-pip \
         software-properties-common \
-        sqlite \
         unzip \
         vim \
-        wget \
-        zlib1g-dev \
-        zlibc; \
+        wget; \
       apt-get -y install ruby-full; \
       apt-get remove -y --purge software-properties-common
 
@@ -54,6 +42,19 @@ RUN pip3 install yq
 
 # bosh
 RUN set -eux; \
+      apt-get -y install \
+        build-essential \
+        libreadline6-dev \
+        libreadline7 \
+        libsqlite3-dev \
+        libssl-dev \
+        libxml2-dev \
+        libxslt-dev \
+        libyaml-dev \
+        openssl \
+        sqlite \
+        zlib1g-dev \
+        zlibc; \
       url="https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${bosh_cli_version}-linux-amd64"; \
       wget -O /usr/local/bin/bosh "${url}"; \
       chmod +x /usr/local/bin/bosh; \


### PR DESCRIPTION
### What is this change about?

Upgrades the cf-d-c-t docker image to have Debian bullseye as the base of the image.

Included some refactors and updates that I think should be relatively minor:
- No longer include the bbl repo at `var/repos/bosh-bootloader`.
- Remove duplicate package installations.
- Remove packages that don't appear to be needed for any specific reason.
- Use ruby 2.7.7 instead of ruby 2.5.4.

### Please provide contextual information.

Closes #165.

### Please check all that apply for this PR:

- [ ] introduces a new task
- [ ] changes an existing task
- [x] changes the Dockerfile
- [x] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None