### PR TITLE
Fix(bbl-up): Use correct flags for new `yq` CLI

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -116,10 +116,10 @@ function main() {
     ns_record_advisory="For DNS delegation to work, please ensure an NS record for ${LB_DOMAIN} is created in its parent DNS zone with the following nameservers:"
     if [[ "$BBL_IAAS" == "aws" ]]; then
       echo "$ns_record_advisory"
-      bbl outputs | yq '.env_dns_zone_name_servers[0:4]' --yaml-output | cut -d' ' -f2
+      bbl outputs | yq '.env_dns_zone_name_servers[0:4]' --output-format yaml | cut -d' ' -f2
     elif [[ "$BBL_IAAS" == "gcp" ]]; then
       echo "$ns_record_advisory"
-      bbl outputs | yq '.system_domain_dns_servers' --yaml-output | cut -d' ' -f2
+      bbl outputs | yq '.system_domain_dns_servers' --output-format yaml | cut -d' ' -f2
     fi
 
     if [[ "${DELETE_TERRAFORM_PLUGINS}" == "true" ]]; then

--- a/bbl-up/task
+++ b/bbl-up/task
@@ -87,7 +87,6 @@ function main() {
       local bbl_cert_chain_flag
       bbl_cert_chain_flag=""
       local bbl_cert_path
-      local bbl_cert_key
       write_bbl_certs
 
       lb_flags="--lb-type=cf --lb-cert=${bbl_cert_path} ${bbl_cert_chain_flag} --lb-key=${bbl_key_path} --lb-domain=${LB_DOMAIN}"


### PR DESCRIPTION
### What is this change about?

Fix failures in bbl-up task in CI by using the correct flags for the new `yq` CLI.

### Please provide contextual information.

- https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/update-releases/jobs/update-stemcell-minor/builds/21
- #167 

### Please check all that apply for this PR:

- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

N/A