### PR TITLE
Option for "bosh-deploy" task to skip stemcell upload

### DIFF
--- a/bosh-deploy/task
+++ b/bosh-deploy/task
@@ -12,7 +12,9 @@ function main() {
   if [ "$REGENERATE_CREDENTIALS" == true ]; then
     remove_credentials_from_credhub
   fi
-  upload_stemcells
+  if [ ! "$SKIP_STEMCELL_UPLOAD" == true ]; then
+    upload_stemcells
+  fi
   # shellcheck disable=SC2086
   bosh_deploy ${BOSH_DEPLOY_ARGS}
 }

--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -63,6 +63,11 @@ params:
   # - Works well with fresh deployments
   # - Upgrade deployments are not expected to work with total cred rotation
 
+  SKIP_STEMCELL_UPLOAD: false
+  # - Optional
+  # - Skip stemcell upload, if stemcell has already been uploaded to BOSH director.
+
+
   # Uptimer Params
   # https://github.com/cloudfoundry/uptimer
   DEPLOY_WITH_UPTIME_MEASUREMENTS: false


### PR DESCRIPTION
### What is this change about?

Add an option to the "bosh-deploy" task to skip the stemcell upload. This is useful in scenarios like the FIPS stemcell validation where the stemcell must be downloaded from a protected storage.

### Please provide contextual information.

Will be used in FIPS stemcell validation pipeline: https://github.com/cloudfoundry/cf-deployment/pull/1135

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

Change does not introduce regressions (i.e. default behaviour stays the same).

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

Docu is in `task.yml`.

### How should this change be described in release notes?

Add option `SKIP_STEMCELL_UPLOAD` to the `bosh-deploy` task.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
