### PR TITLE
fix: SYSTEM_DOMAIN incorrectly extracted from toolsmiths-env

### DIFF
--- a/shared-functions
+++ b/shared-functions
@@ -86,7 +86,7 @@ function setup_bosh_env_vars() {
   set +x
   if [ -d toolsmiths-env ]; then
     eval "$(bbl print-env --metadata-file toolsmiths-env/metadata)"
-    export SYSTEM_DOMAIN="$(cat toolsmiths-env/metadata | jq -r .name).cf-app.com"
+    export SYSTEM_DOMAIN="$(cat toolsmiths-env/metadata | jq -r '.cf.api_url | sub("api."; "")')"
     export TCP_DOMAIN="tcp.${SYSTEM_DOMAIN}"
   else
     if [ -d bbl-state ]; then


### PR DESCRIPTION
[Fixes #178]

### What is this change about?

Fixes an issue where SYSTEM_DOMAIN is sometimes incorrectly extracted from "toolsmiths-env" input. 

### Please provide contextual information.

n/a

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

_Something brief that conveys the change and is written with the component author audience in mind._



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
