### PR TITLE
Add ability for setting app_stats

### DIFF
--- a/bosh-deploy-with-created-release/task.yml
+++ b/bosh-deploy-with-created-release/task.yml
@@ -122,6 +122,11 @@ params:
   # - This sets the maximum number of allowed uptimer failures for app pushability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
 
+  APP_STATS_THRESHOLD: 0
+  # - Optional
+  # - This sets the maximum number of allowed uptimer failures for app stats
+  # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+
   HTTP_AVAILABILITY_THRESHOLD: 0
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for http availability

--- a/bosh-deploy-with-updated-release-submodule/task.yml
+++ b/bosh-deploy-with-updated-release-submodule/task.yml
@@ -111,6 +111,11 @@ params:
   # - This sets the maximum number of allowed uptimer failures for app pushability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
 
+  APP_STATS_THRESHOLD: 0
+  # - Optional
+  # - This sets the maximum number of allowed uptimer failures for app stats
+  # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+
   HTTP_AVAILABILITY_THRESHOLD: 0
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for http availability

--- a/bosh-deploy/task.yml
+++ b/bosh-deploy/task.yml
@@ -110,6 +110,11 @@ params:
   # - This sets the maximum number of allowed uptimer failures for app pushability
   # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
 
+  APP_STATS_THRESHOLD: 0
+  # - Optional
+  # - This sets the maximum number of allowed uptimer failures for app stats
+  # - The default threshold value of 0 is our working value for cf-deployment, and is likely to be updated
+
   HTTP_AVAILABILITY_THRESHOLD: 0
   # - Optional
   # - This sets the maximum number of allowed uptimer failures for http availability

--- a/shared-functions
+++ b/shared-functions
@@ -210,6 +210,7 @@ write_uptimer_deploy_config() {
     --arg tcp_port ${tcp_port} \
     --arg available_port ${available_port} \
     --arg app_pushability ${APP_PUSHABILITY_THRESHOLD} \
+    --arg app_stats ${APP_STATS_THRESHOLD} \
     --arg http_availability ${HTTP_AVAILABILITY_THRESHOLD} \
     --arg tcp_availability ${TCP_AVAILABILITY_THRESHOLD} \
     --arg recent_logs ${RECENT_LOGS_THRESHOLD} \
@@ -234,6 +235,7 @@ write_uptimer_deploy_config() {
       },
       "allowed_failures": {
         "app_pushability": $app_pushability | tonumber,
+        "app_stats": $app_stats | tonumber,
         "http_availability": $http_availability | tonumber,
         "tcp_availability": $tcp_availability | tonumber,
         "recent_logs": $recent_logs | tonumber,


### PR DESCRIPTION
### What is this change about?
After adding this new measurement, our CI is failing this measurement because the default value of 0 is too aggresssive for cf-deployment when routing-release is getting updated. This PR adds the ablity to set app_stats when needed.


### Please provide contextual information.
Context: cloudfoundry/uptimer#115


### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [x] YES
- [ ] N/A



### How should this change be described in release notes?

Add ability for setting app_stats 



### What is the level of urgency for publishing this change?
- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
