### PR TITLE
Upgrade to debian bookworm (ruby 3.1)

### DIFF
--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.5-bullseye
+FROM golang:1.22.5-bookworm
 
 ENV bbl_version 9.0.24
 ENV bosh_cli_version 7.6.2
@@ -23,7 +23,7 @@ RUN set -eux; \
 # ruby
 RUN set -eux; \
       apt-get -y install ruby-full; \
-      ruby --version | grep 2\.7
+      ruby --version | grep 3\.1
 
 # yq
 RUN set -eux; \


### PR DESCRIPTION
### What is this change about?

This upgrades the Dockerfile to Debian bookworm.

### Please provide contextual information.


the primary reason for the change is to address #191. We need a newer version of ruby that supports the latest release of the `bosh-template` gem used in RSpec suites.


### Please check all that apply for this PR:
- [ ] introduces a new task
- [ ] changes an existing task
- [x] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Upgrade to Debian bookworm (ruby 2.7 -> 3.1) in Dockerfile.



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
cc @ctlong 
