### PR TITLE
Fix log cache plugin asset name

### DIFF
--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -4,7 +4,7 @@ ENV bbl_version 9.0.25
 ENV bosh_cli_version 7.8.0
 ENV cf_cli_version 8.8.2
 ENV credhub_cli_version 2.9.38
-ENV log_cache_cli_version 6.0.2
+ENV log_cache_cli_version 6.1.0
 ENV terraform_version 1.9.7
 ENV uptimer_version 25c5d98ca42cda8e2616160431c4add4952ea33d
 ENV yq_version 4.44.3
@@ -92,7 +92,7 @@ RUN set -eux; \
 
 # log-cache
 RUN set -eux; \
-      url="https://github.com/cloudfoundry/log-cache-cli/releases/download/v${log_cache_cli_version}/log-cache-cf-plugin-linux"; \
+      url="https://github.com/cloudfoundry/log-cache-cli/releases/download/v${log_cache_cli_version}/log-cache-cf-plugin_${log_cache_cli_version}_linux_amd64"; \
       wget "${url}" -O /tmp/log-cache-plugin; \
       cf install-plugin /tmp/log-cache-plugin -f; \
       rm /tmp/log-cache-plugin


### PR DESCRIPTION
Assets name for the log-cache-cf-plugin was changed. As a result, the build-docker-image job is failing and this change need to be propagated....

### What is this change about?

_Describe the change and why it's needed._

 Fixe the downloadable asset name for log-cache-cf-plugin used in  Dockefile.

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._
https://github.com/cloudfoundry/log-cache-cli/pull/257


### Please check all that apply for this PR:
- [ ] introduces a new task
- [ ] changes an existing task
- [x] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A



### How should this change be described in release notes?

N/A



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
