### PR TITLE
fix(shared-functions): Check for BOSH_LITE first in upload_stemcell function

### DIFF
--- a/shared-functions
+++ b/shared-functions
@@ -444,9 +444,7 @@ upload_stemcell() {
   else
     infrastructure="$(jq -r .iaas bbl-state/${BBL_STATE_DIR}/bbl-state.json)"
 
-    if [ "$infrastructure" = "bosh-lite" ]; then
-      stemcell_name="bosh-warden-boshlite"
-    elif [ "$infrastructure" = "aws" ]; then
+    if [ "$infrastructure" = "aws" ]; then
       stemcell_name="bosh-aws-xen-hvm"
     elif [ "$infrastructure" = "gcp" ]; then
       stemcell_name="bosh-google-kvm"

--- a/shared-functions
+++ b/shared-functions
@@ -435,15 +435,14 @@ upload_stemcell() {
   local stemcell_name
 
   local infrastructure
-  if [ -d toolsmiths-env ]; then
+  if [ "${BOSH_LITE}" == "true"  ]; then
+    infrastructure="bosh-lite"
+    stemcell_name="bosh-warden-boshlite"
+  elif [ -d toolsmiths-env ]; then
     infrastructure="gcp"
     stemcell_name="bosh-google-kvm"
   else
     infrastructure="$(jq -r .iaas bbl-state/${BBL_STATE_DIR}/bbl-state.json)"
-
-    if [ "${BOSH_LITE}" == "true"  ]; then
-      infrastructure="bosh-lite"
-    fi
 
     if [ "$infrastructure" = "bosh-lite" ]; then
       stemcell_name="bosh-warden-boshlite"


### PR DESCRIPTION
### What is this change about?

The upload_stemcell function checks if the BOSH_LITE variable is true before checking anything else. Fixes an edge case where toolsmiths-env exists but is a BOSH_LITE.

### Please provide contextual information.

None

### Please check all that apply for this PR:

- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None