### PR TITLE
Obtain the load balancer type dynamically

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -85,11 +85,12 @@ function main() {
 
     if [ "${SKIP_LB_CREATION}" == "false" ]; then
       local bbl_cert_chain_flag
+      local bbl_lb_type="${BBL_LB_TYPE}" 
       bbl_cert_chain_flag=""
       local bbl_cert_path
       write_bbl_certs
 
-      lb_flags="--lb-type=cf --lb-cert=${bbl_cert_path} ${bbl_cert_chain_flag} --lb-key=${bbl_key_path} --lb-domain=${LB_DOMAIN}"
+      lb_flags="--lb-type=${bb_lb_type} --lb-cert=${bbl_cert_path} ${bbl_cert_chain_flag} --lb-key=${bbl_key_path} --lb-domain=${LB_DOMAIN}"
     fi
 
     set -o pipefail

--- a/bbl-up/task.yml
+++ b/bbl-up/task.yml
@@ -114,6 +114,12 @@ params:
   # - Can be either the key content or a path to the key
   # - If a path is provided, path is relative to the BBL_STATE_DIR
 
+  BBL_LB_TYPE: cf
+  # - Defines the type of load balancer to be configured.
+  # - The default type is 'cf', suitable for most environments.
+  # - You can specify a different type based on your application's requirements.
+  # - For the new IPv6 validation, the 'nlb' type is necessary.
+
   LB_DOMAIN:
   # - Required if `SKIP_LB_CREATION` is false
   # - The domain which bbl will register


### PR DESCRIPTION
### What is this change about?

The change involves updating the bbl-up task to dynamically set the load balancer type. This is necessary to prepare for future IPv6 tests, which require switching to the 'nlb' type for dualstack support. Currently, the default is 'cf', suitable for IPv4, but updating to 'nlb' ensures compatibility with IPv6 testing requirements. This enhances network flexibility and readiness.


### Please provide contextual information.

This adjustment to the pipeline is required as a result of this PR:

https://github.com/cloudfoundry/bosh-bootloader/pull/644


### Please check all that apply for this PR:
- [ ] introduces a new task
- [X] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A



### How should this change be described in release notes?

Enhanced bbl-up task to support dynamic load balancer configuration


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@oliver-heinrich @jochenehret @iaftab-alam 