### PR TITLE
Adjust the stemcell_name in the shared functions for Noble

### DIFF
--- a/shared-functions
+++ b/shared-functions
@@ -457,7 +457,11 @@ upload_stemcell() {
     fi
   fi
 
-  stemcell_name="${stemcell_name}-${os}-go_agent"
+  stemcell_name="${stemcell_name}-${os}"
+  if [ "$os" != "ubuntu-noble" ]; then
+    stemcell_name="${stemcell_name}-go_agent"
+  fi
+
   if [ "$version" = "latest" ]; then
     full_stemcell_url="${stemcells_url}/${stemcell_name}"
   else


### PR DESCRIPTION
### What is this change about?

This update modifies the logic in a shared function to handle stemcell naming conventions more accurately. 

### Please provide contextual information.

The adjustment ensures that the suffix "go_agent" is not appended to the stemcell_name when using the "ubuntu-noble" operating system stemcell. This allows for more flexible use of stemcells based on their operating system, adhering to naming conventions that differentiate between stemcell types.

### Please check all that apply for this PR:
- [ ] introduces a new task
- [X] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)



### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A


### How should this change be described in release notes?

Improvement: Stemcell Naming
Adjusted naming logic to exclude "go_agent" for "ubuntu-noble" stemcells, aligning with OS-specific conventions.



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
