### PR TITLE
Add "Azure" to DNS advisory check

### DIFF
--- a/bbl-up/task
+++ b/bbl-up/task
@@ -112,13 +112,15 @@ function main() {
       ${name_flag} \
       ${lb_flags} "2>&1" ${drain} "${root_dir}/bbl_up.log"
 
-    ns_record_advisory="For DNS delegation to work, please ensure an NS record for ${LB_DOMAIN} is created in its parent DNS zone with the following nameservers:"
+    echo "For DNS delegation to work, please ensure an NS record for ${LB_DOMAIN} is created in its parent DNS zone with the following nameservers:"
     if [[ "$BBL_IAAS" == "aws" ]]; then
-      echo "$ns_record_advisory"
       bbl outputs | yq '.env_dns_zone_name_servers[0:4]' --output-format yaml | cut -d' ' -f2
-    elif [[ "$BBL_IAAS" == "gcp" ]]; then
-      echo "$ns_record_advisory"
-      bbl outputs | yq '.system_domain_dns_servers' --output-format yaml | cut -d' ' -f2
+    elif [[ "$BBL_IAAS" == "gcp" || "$BBL_IAAS" == "azure" ]]; then
+      if bbl outputs | yq '.system_domain_dns_servers' | grep -qv 'null'; then
+        bbl outputs | yq '.system_domain_dns_servers' --output-format yaml | cut -d' ' -f2
+      else
+        echo "No .system_domain_dns_servers found in bbl outputs. Please refer to the GCP/Azure portal to get the DNS servers for the created DNS zone."
+      fi
     fi
 
     if [[ "${DELETE_TERRAFORM_PLUGINS}" == "true" ]]; then


### PR DESCRIPTION
### What is this change about?

Small enhancement for "Azure" infrastructures. Print the list of DNS name servers if it is contained in `bbl outputs`.

### Please provide contextual information.

https://github.com/cloudfoundry/cloud_controller_ng/pull/4397

### Please check all that apply for this PR:
- [ ] introduces a new task
- [x] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in release notes?

The `bbl-up` task now prints the DNS name servers for Azure bbl installations (if available in `bbl outputs`).

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
