### PR TITLE
Add gh cli for kind-deployment validation

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -34,6 +34,15 @@ resources:
     access_token: ((ard_wg_gitbot_token))
     tag_filter: 'v(8\.[^v].*)'
 
+- name: gh-cli-github-release
+  type: github-release
+  icon: github
+  source:
+    user: cli
+    repository: cli
+    access_token: ((ard_wg_gitbot_token))
+    tag_filter: 'v(.*)'
+
 - name: credhub-cli-github-release
   type: github-release
   icon: github
@@ -127,6 +136,8 @@ jobs:
       trigger: true
     - get: cf-cli-github-release
       trigger: true
+    - get: gh-cli-github-release
+      trigger: true
     - get: cf-deployment-concourse-tasks-dockerfile
       trigger: true
     - get: credhub-cli-github-release
@@ -143,6 +154,7 @@ jobs:
     file: cf-deployment-concourse-tasks-dockerfile/ci/tasks/update-cf-d-ct-dockerfile-versions/task.yml
     input_mapping:
       cf-cli: cf-cli-github-release
+      gh-cli: gh-cli-github-release
       cf-deployment-concourse-tasks: cf-deployment-concourse-tasks-dockerfile
   - put: cf-deployment-concourse-tasks-pipeline-image
     params:

--- a/ci/tasks/update-cf-d-ct-dockerfile-versions/task
+++ b/ci/tasks/update-cf-d-ct-dockerfile-versions/task
@@ -5,6 +5,7 @@ dockerfile="cf-deployment-concourse-tasks/dockerfiles/cf-deployment-concourse-ta
 sed -i "s/ENV bbl_version.*$/ENV bbl_version $(cat bbl-github-release/version)/" $dockerfile
 sed -i "s/ENV bosh_cli_version.*$/ENV bosh_cli_version $(cat bosh-cli-github-release/version)/" $dockerfile
 sed -i "s/ENV cf_cli_version.*$/ENV cf_cli_version $(cat cf-cli/version)/" $dockerfile
+sed -i "s/ENV gh_cli_version.*$/ENV gh_cli_version $(cat gh-cli/version)/" $dockerfile
 sed -i "s/ENV credhub_cli_version.*$/ENV credhub_cli_version $(cat credhub-cli-github-release/version)/" $dockerfile
 sed -i "s/ENV log_cache_cli_version.*$/ENV log_cache_cli_version $(cat log-cache-cli-github-release/version)/" $dockerfile
 sed -i "s/ENV terraform_version.*$/ENV terraform_version $(cat terraform-github-release/version)/" $dockerfile

--- a/ci/tasks/update-cf-d-ct-dockerfile-versions/task.yml
+++ b/ci/tasks/update-cf-d-ct-dockerfile-versions/task.yml
@@ -10,6 +10,7 @@ inputs:
 - name: bbl-github-release
 - name: bosh-cli-github-release
 - name: cf-cli
+- name: gh-cli
 - name: cf-deployment-concourse-tasks
 - name: credhub-cli-github-release
 - name: log-cache-cli-github-release

--- a/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
+++ b/dockerfiles/cf-deployment-concourse-tasks/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.26.4-bookworm
 ENV bbl_version 9.0.45
 ENV bosh_cli_version 7.10.6
 ENV cf_cli_version 8.18.4
+ENV gh_cli_version 2.76.1
 ENV credhub_cli_version 2.9.58
 ENV log_cache_cli_version 6.2.1
 ENV terraform_version 1.15.8
@@ -60,6 +61,17 @@ RUN set -eux; \
       chmod +x /usr/local/bin/cf; \
       cf version; \
       rm -rf /tmp/cf
+
+# gh
+RUN set -eux; \
+      mkdir -p /tmp/gh; \
+      url="https://github.com/cli/cli/releases/download/v${gh_cli_version}/gh_${gh_cli_version}_linux_amd64.tar.gz"; \
+      wget "${url}" -O /tmp/gh/gh.tar.gz; \
+      tar -xzf /tmp/gh/gh.tar.gz -C /tmp/gh; \
+      mv /tmp/gh/gh_${gh_cli_version}_linux_amd64/bin/gh /usr/local/bin/gh; \
+      chmod +x /usr/local/bin/gh; \
+      gh --version; \
+      rm -rf /tmp/gh
 
 # credhub
 RUN set -eux; \


### PR DESCRIPTION
### What is this change about?

This PR adds the gh CLI to the cf-deployment-concourse-tasks Docker image.

### Please provide contextual information.

As we try to introduce [new kind-deployment validation job]() we need add gh cli. 

As we try to introduce a [new kind-deployment validation job](https://github.com/cloudfoundry/cf-deployment/pull/1359) we need to add the gh CLI. The gh CLI is installed from the official [cli/cli](https://github.com/cli/cli) GitHub releases and its version is automatically kept up to date via the existing Concourse pipeline.

### Please check all that apply for this PR:
- [ ] introduces a new task
- [ ] changes an existing task
- [X] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A

### How should this change be described in release notes?

Added gh CLI to the cf-deployment-concourse-tasks Docker image.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!
@jochenehret 
