### PR TITLE
Make [get|setup]_password_from_credhub functions more resilient

### DIFF
--- a/shared-functions
+++ b/shared-functions
@@ -354,19 +354,25 @@ get_password_from_credhub() {
   set +x
   local bosh_manifest_password_variable_name=$1
 
-  local credential_path=$(credhub find -j -n ${bosh_manifest_password_variable_name} | jq -r .credentials[].name )
-  local credential_paths_len=$(echo ${credential_path} | tr ' ' '\n' | wc -l)
+  local credential_paths
+  credential_paths=$(credhub find -j -n "${bosh_manifest_password_variable_name}" | jq -r '.credentials[].name')
+
+  local credential_paths_len
+  credential_paths_len=$(printf '%s\n' "${credential_paths}" | sed '/^$/d' | wc -l | tr -d '[:space:]')
 
   if [ "${credential_paths_len}" -gt 1 ]; then
     echo "ambiguous ${bosh_manifest_password_variable_name} variable name; expected one got ${credential_paths_len}" >&2
-    echo "${credential_path}" | tr ' ' '\n' >&2
-    return
+    echo "${credential_paths}" | tr ' ' '\n' >&2
+    return 1
   elif [ "${credential_paths_len}" -eq 0 ]; then
     echo "${bosh_manifest_password_variable_name} variable not found" >&2
-    return
+    return 1
   fi
 
-  echo $(credhub find -j -n ${bosh_manifest_password_variable_name} | jq -r .credentials[].name | xargs credhub get -j -n | jq -r .value)
+  local credential_path
+  credential_path=$(printf '%s\n' "${credential_paths}" | head -n 1)
+
+  credhub get -j -n "${credential_path}" | jq -r .value
   set -x
 }
 
@@ -378,15 +384,21 @@ setup_password_from_credhub() {
     environment_variable_name=$2
   fi
 
-  local credential_path=$(credhub find -j -n ${bosh_manifest_password_variable_name} | jq -r .credentials[].name )
-  local credential_paths_len=$(echo ${credential_path} | tr ' ' '\n' | wc -l)
+  local credential_path
+  credential_path=$(credhub find -j -n "${bosh_manifest_password_variable_name}" | jq -r '.credentials[].name')
+
+  local credential_paths_len
+  credential_paths_len=$(printf '%s\n' "${credential_path}" | sed '/^$/d' | wc -l | tr -d '[:space:]')
   if [ "${credential_paths_len}" -gt 1 ]; then
     echo "ambiguous password variable name; expected one got ${credential_paths_len}"
     echo "${credential_path}" | tr ' ' '\n'
     exit 1
+  elif [ "${credential_paths_len}" -eq 0 ]; then
+    echo "${bosh_manifest_password_variable_name} variable not found"
+    exit 1
   fi
 
-  export "${environment_variable_name}"=$(credhub find -j -n ${bosh_manifest_password_variable_name} | jq -r .credentials[].name | xargs credhub get -j -n | jq -r .value)
+  export "${environment_variable_name}"="$(get_password_from_credhub "${bosh_manifest_password_variable_name}")"
   set -x
 }
 


### PR DESCRIPTION
### What is this change about?

Harden CredHub password lookup to fail fast on missing credentials.

### Please provide contextual information.

The `updated-integration-configs` task sometimes fails:
```
+ set -o pipefail
+ source cf-deployment-concourse-tasks/shared-functions
+ trap commit_integration_configs EXIT
+ main /tmp/build/0d3b4bb9
+ local root_dir
+ root_dir=/tmp/build/0d3b4bb9
+ check_fast_fails
+ '[' '!' -f integration-configs/elsa-ha/cats_integration_config.json -a '!' -f integration-configs/rats_integration_config.json -a '!' -f integration-configs/wats_integration_config.json ']'
+ setup_bosh_env_vars
+ set +x
/tmp/build/0d3b4bb9/bbl-state/elsa-ha/bbl-state /tmp/build/0d3b4bb9
/tmp/build/0d3b4bb9
+ set +x
The provided authentication mechanism does not provide a valid identity. Please contact your system administrator.
The provided authentication mechanism does not provide a valid identity. Please contact your system administrator.
expected argument for flag `-n, --name'
updating CATs integration config file: elsa-ha/cats_integration_config.json...
```
The result is an incomplete configuration file with an empty admin password. Subsequent test jobs will fail.
Example job: https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team/pipelines/capi/jobs/elsa-ha-tests/builds/648

This change correctly counts the number of retrieved credentials and fails fast in case of unexpected results. Note that it doesn't retry the `credhub` CLI operation. That can now be done in the Concourse task.

### Please check all that apply for this PR:
- [ ] introduces a new task
- [ ] changes an existing task
- [ ] changes the Dockerfile
- [ ] introduces a breaking change (other users will need to make manual changes when this is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in release notes?

Harden CredHub password lookup to fail fast on missing credentials.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
